### PR TITLE
[FEAT] Swagger 버전 수정 및 question 날짜별 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/efub/cpbr/crumble/global/exception/ErrorCode.java
+++ b/src/main/java/efub/cpbr/crumble/global/exception/ErrorCode.java
@@ -7,10 +7,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
     ERROR(400, "요청 처리에 실패했습니다."),
-    UNAUTHORIZED_ACCESS(401, "인증되지 않은 사용자입니다.");
+    UNAUTHORIZED_ACCESS(401, "인증되지 않은 사용자입니다."),
 
-    // {특정 도메인} 관련 에러
-    // 추가
+    // Question 관련 에러
+    QUESTION_NOT_FOUND(404, "해당 날짜의 질문이 존재하지 않습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/efub/cpbr/crumble/question/controller/QuestionController.java
+++ b/src/main/java/efub/cpbr/crumble/question/controller/QuestionController.java
@@ -1,0 +1,31 @@
+package efub.cpbr.crumble.question.controller;
+
+import efub.cpbr.crumble.question.dto.res.QuestionResponse;
+import efub.cpbr.crumble.question.service.QuestionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@Tag(name = "Question", description = "질문 관련 API")
+@RestController
+@RequiredArgsConstructor
+public class QuestionController {
+    private final QuestionService questionService;
+
+    @Operation(
+            summary = "특정 날짜의 질문 조회",
+            description = "날짜(yyyy-MM-dd)별로 질문을 조회합니다."
+    )
+    @GetMapping("/question/{date}")
+    public ResponseEntity<QuestionResponse> getQuestion(
+            @Parameter(description = "조회할 날짜 (yyyy-MM-dd)", example = "2025-07-08") @PathVariable LocalDate date) {
+        return ResponseEntity.ok(questionService.getQuestion(date));
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/question/dto/res/QuestionResponse.java
+++ b/src/main/java/efub/cpbr/crumble/question/dto/res/QuestionResponse.java
@@ -1,0 +1,15 @@
+package efub.cpbr.crumble.question.dto.res;
+
+import efub.cpbr.crumble.question.entity.Question;
+
+public record QuestionResponse(Long questionId,
+                               String date,
+                               String content) {
+    public static QuestionResponse from(Question question) {
+        return new QuestionResponse(
+                question.getId(),
+                question.getDate().toString(),
+                question.getContent()
+        );
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/question/entity/Question.java
+++ b/src/main/java/efub/cpbr/crumble/question/entity/Question.java
@@ -1,11 +1,25 @@
 package efub.cpbr.crumble.question.entity;
 
 import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
 
 @Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(toBuilder = true)
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"date"}))
 public class Question {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name="question_id")
     private Long id;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(nullable = false)
+    private String content;
 }

--- a/src/main/java/efub/cpbr/crumble/question/repository/QuestionRepository.java
+++ b/src/main/java/efub/cpbr/crumble/question/repository/QuestionRepository.java
@@ -1,0 +1,11 @@
+package efub.cpbr.crumble.question.repository;
+
+import efub.cpbr.crumble.question.entity.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+    Optional<Question> findByDate(LocalDate date);
+}

--- a/src/main/java/efub/cpbr/crumble/question/service/QuestionService.java
+++ b/src/main/java/efub/cpbr/crumble/question/service/QuestionService.java
@@ -1,0 +1,25 @@
+package efub.cpbr.crumble.question.service;
+
+import efub.cpbr.crumble.global.exception.CustomException;
+import efub.cpbr.crumble.global.exception.ErrorCode;
+import efub.cpbr.crumble.question.dto.res.QuestionResponse;
+import efub.cpbr.crumble.question.entity.Question;
+import efub.cpbr.crumble.question.repository.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionService {
+    private final QuestionRepository questionRepository;
+
+    @Transactional(readOnly = true)
+    public QuestionResponse getQuestion(LocalDate date) {
+        Question question = questionRepository.findByDate(date).
+                orElseThrow(() -> new CustomException(ErrorCode.QUESTION_NOT_FOUND));
+        return QuestionResponse.from(question);
+    }
+}


### PR DESCRIPTION
## 🔧 작업 사항(Summary)<!--- 진행한 작업에 대해 설명해주세요. -->
- [x] swagger 버전 호환성 문제 해결 
- [x] question date별 조회 api 구현 

## ✨ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 빌드 부분 혹은 패키지 매니저 수정


## 📸 스크린샷 or Test 결과 (선택)
DB에 우선 임의의 값을 생성 후 Swagger 테스트 했습니다. 
- 정상 조회 
<img width="781" height="263" alt="image" src="https://github.com/user-attachments/assets/daf5c437-8069-49ec-9c06-2307be92ae04" />
<br/>

- 에러 처리

<img width="844" height="301" alt="image" src="https://github.com/user-attachments/assets/2c94d9a8-f22d-45ad-9ec3-9dbbf82d32da" />

## 기타 
swagger 테스트 시 java.lang.NoSuchMethodError: 'void org.springframework.web.method.ControllerAdviceBean.<init>(java.lang.Object) 에러가 발생하여 구글링했더니 spring boot 버전 업데이트로 인해 swagger 2.5.x 버전과 호환성 문제가 발생하여 2.8.9 최신 버전으로 수정했습니다. 재빌드 후 테스트 하시면 될 것 같습니다 -!


## 📌 Issue Number<!--- ex) #이슈이름, #이슈번호 -->

- #9 
