### PR TITLE
[FEAT] Answer 생성, 조회 api 및 유효성 검증 처리 추가 

### DIFF
--- a/src/main/java/efub/cpbr/crumble/answer/controller/AnswerController.java
+++ b/src/main/java/efub/cpbr/crumble/answer/controller/AnswerController.java
@@ -4,6 +4,12 @@ import efub.cpbr.crumble.answer.dto.req.AnswerRequest;
 import efub.cpbr.crumble.answer.dto.res.AnswerResponse;
 import efub.cpbr.crumble.answer.service.AnswerService;
 import efub.cpbr.crumble.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 import java.net.URI;
 import java.time.LocalDate;
 
+@Tag(name = "Answer", description = "답변 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/question/{date}/answer")
@@ -18,19 +25,36 @@ public class AnswerController {
 
     private final AnswerService answerService;
 
+    @Operation(
+            summary = "답변 생성",
+            description = "특정 날짜의 질문에 대한 답변을 생성합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "생성 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 데이터 오류"),
+            @ApiResponse(responseCode = "404", description = "질문 또는 유저 없음")
+    })
     @PostMapping
     public ResponseEntity<Void> createAnswer(//@AuthenticationPrincipal
                                              User user,
-                                             @PathVariable LocalDate date,
+                                             @Parameter(description = "질문 날짜", example = "2024-07-17") @PathVariable LocalDate date,
                                              @RequestBody AnswerRequest request) {
         Long answerId = answerService.createAnswer(user, date,request);
         return ResponseEntity.created(URI.create("/question/"+date+"/answer/"+answerId)).build();
     }
 
+    @Operation(
+            summary = "답변 조회",
+            description = "특정 날짜, 특정 유저의 답변을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "답변 없음")
+    })
     @GetMapping
     public ResponseEntity<AnswerResponse> getAnswer(//@AuthenticationPrincipal
                                                     User user,
-                                                    @PathVariable LocalDate date){
+                                                    @Parameter(description = "질문 날짜", example = "2024-07-17") @PathVariable LocalDate date){
         return ResponseEntity.ok(answerService.getAnswer(user,date));
     }
 }

--- a/src/main/java/efub/cpbr/crumble/answer/controller/AnswerController.java
+++ b/src/main/java/efub/cpbr/crumble/answer/controller/AnswerController.java
@@ -38,7 +38,7 @@ public class AnswerController {
     public ResponseEntity<Void> createAnswer(//@AuthenticationPrincipal
                                              User user,
                                              @Parameter(description = "질문 날짜", example = "2024-07-17") @PathVariable LocalDate date,
-                                             @RequestBody AnswerRequest request) {
+                                             @Valid @RequestBody AnswerRequest request) {
         Long answerId = answerService.createAnswer(user, date,request);
         return ResponseEntity.created(URI.create("/question/"+date+"/answer/"+answerId)).build();
     }

--- a/src/main/java/efub/cpbr/crumble/answer/controller/AnswerController.java
+++ b/src/main/java/efub/cpbr/crumble/answer/controller/AnswerController.java
@@ -1,0 +1,36 @@
+package efub.cpbr.crumble.answer.controller;
+
+import efub.cpbr.crumble.answer.dto.req.AnswerRequest;
+import efub.cpbr.crumble.answer.dto.res.AnswerResponse;
+import efub.cpbr.crumble.answer.service.AnswerService;
+import efub.cpbr.crumble.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.time.LocalDate;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/question/{date}/answer")
+public class AnswerController {
+
+    private final AnswerService answerService;
+
+    @PostMapping
+    public ResponseEntity<Void> createAnswer(//@AuthenticationPrincipal
+                                             User user,
+                                             @PathVariable LocalDate date,
+                                             @RequestBody AnswerRequest request) {
+        Long answerId = answerService.createAnswer(user, date,request);
+        return ResponseEntity.created(URI.create("/question/"+date+"/answer/"+answerId)).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<AnswerResponse> getAnswer(//@AuthenticationPrincipal
+                                                    User user,
+                                                    @PathVariable LocalDate date){
+        return ResponseEntity.ok(answerService.getAnswer(user,date));
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/answer/dto/req/AnswerRequest.java
+++ b/src/main/java/efub/cpbr/crumble/answer/dto/req/AnswerRequest.java
@@ -3,6 +3,9 @@ package efub.cpbr.crumble.answer.dto.req;
 import efub.cpbr.crumble.answer.entity.Answer;
 import efub.cpbr.crumble.question.entity.Question;
 import efub.cpbr.crumble.user.entity.User;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
 @Getter
@@ -10,7 +13,11 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class AnswerRequest {
+    @NotBlank(message = "답변 내용을 입력해주세요.")
+    @Size(min = 50, message = "최소 글자수를 충족하지 못했습니다.")
     private String content;
+
+    @NotNull(message = "공개 여부를 선택해주세요.")
     private Boolean isPublic;
 
     public Answer toEntity(Question question, User user) {

--- a/src/main/java/efub/cpbr/crumble/answer/dto/req/AnswerRequest.java
+++ b/src/main/java/efub/cpbr/crumble/answer/dto/req/AnswerRequest.java
@@ -1,0 +1,24 @@
+package efub.cpbr.crumble.answer.dto.req;
+
+import efub.cpbr.crumble.answer.entity.Answer;
+import efub.cpbr.crumble.question.entity.Question;
+import efub.cpbr.crumble.user.entity.User;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AnswerRequest {
+    private String content;
+    private Boolean isPublic;
+
+    public Answer toEntity(Question question, User user) {
+        return Answer.builder()
+                .content(content)
+                .isPublic(isPublic)
+                .user(user)
+                .question(question)
+                .build();
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/answer/dto/res/AnswerResponse.java
+++ b/src/main/java/efub/cpbr/crumble/answer/dto/res/AnswerResponse.java
@@ -1,0 +1,31 @@
+package efub.cpbr.crumble.answer.dto.res;
+
+import efub.cpbr.crumble.answer.entity.Answer;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AnswerResponse {
+    private final Long answerId;
+    private final Long questionId;
+    private final Long userId;
+    private final String content;
+    private final Boolean isPublic;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static AnswerResponse of(Answer answer) {
+        return AnswerResponse.builder()
+                .answerId(answer.getId())
+                .questionId(answer.getQuestion().getId())
+                .userId(answer.getUser().getId())
+                .content(answer.getContent())
+                .isPublic(answer.getIsPublic())
+                .createdAt(answer.getCreatedAt())
+                .updatedAt(answer.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/answer/entity/Answer.java
+++ b/src/main/java/efub/cpbr/crumble/answer/entity/Answer.java
@@ -1,6 +1,7 @@
 package efub.cpbr.crumble.answer.entity;
 
 import efub.cpbr.crumble.community.post.domain.Post;
+import efub.cpbr.crumble.global.domain.BaseEntity;
 import efub.cpbr.crumble.question.entity.Question;
 import efub.cpbr.crumble.user.entity.User;
 import jakarta.persistence.*;
@@ -13,7 +14,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder(toBuilder = true)
-public class Answer {
+public class Answer extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name="answer_id")
@@ -35,11 +36,5 @@ public class Answer {
 
     @OneToOne(mappedBy = "answer", fetch = FetchType.LAZY)
     private Post post;
-
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(nullable = false)
-    private LocalDateTime updatedAt;
 
 }

--- a/src/main/java/efub/cpbr/crumble/answer/repository/AnswerRepository.java
+++ b/src/main/java/efub/cpbr/crumble/answer/repository/AnswerRepository.java
@@ -1,0 +1,12 @@
+package efub.cpbr.crumble.answer.repository;
+
+import efub.cpbr.crumble.answer.entity.Answer;
+import efub.cpbr.crumble.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+    Optional<Answer> findByUserAndQuestion_Date(User user, LocalDate date);
+}

--- a/src/main/java/efub/cpbr/crumble/answer/service/AnswerService.java
+++ b/src/main/java/efub/cpbr/crumble/answer/service/AnswerService.java
@@ -1,0 +1,38 @@
+package efub.cpbr.crumble.answer.service;
+
+import efub.cpbr.crumble.answer.dto.req.AnswerRequest;
+import efub.cpbr.crumble.answer.dto.res.AnswerResponse;
+import efub.cpbr.crumble.answer.entity.Answer;
+import efub.cpbr.crumble.answer.repository.AnswerRepository;
+import efub.cpbr.crumble.global.exception.CustomException;
+import efub.cpbr.crumble.global.exception.ErrorCode;
+import efub.cpbr.crumble.question.entity.Question;
+import efub.cpbr.crumble.question.service.QuestionService;
+import efub.cpbr.crumble.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class AnswerService {
+    private final AnswerRepository answerRepository;
+    private final QuestionService questionService;
+
+    @Transactional
+    public Long createAnswer(User user, LocalDate date, AnswerRequest request){
+        Question question = questionService.findQuestionByIdOrThrow(date);
+
+        Answer answer = request.toEntity(question,user);
+        return answerRepository.save(answer).getId();
+    }
+
+    @Transactional(readOnly = true)
+    public AnswerResponse getAnswer(User user, LocalDate date){
+        Answer answer=answerRepository.findByUserAndQuestion_Date(user,date)
+                .orElseThrow(()->new CustomException(ErrorCode.ANSWER_NOT_FOUND));
+        return AnswerResponse.of(answer);
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/global/exception/ErrorCode.java
+++ b/src/main/java/efub/cpbr/crumble/global/exception/ErrorCode.java
@@ -11,6 +11,8 @@ public enum ErrorCode {
 
     // Question 관련 에러
     QUESTION_NOT_FOUND(404, "해당 날짜의 질문이 존재하지 않습니다."),
+    // Answer 관련 에러
+    ANSWER_NOT_FOUND(404, "해당 답변이 존재하지 않습니다."),
 
     // community
     ALREADY_LIKED(400, "이미 좋아요를 누른 게시글입니다."),

--- a/src/main/java/efub/cpbr/crumble/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/efub/cpbr/crumble/global/exception/GlobalExceptionHandler.java
@@ -2,8 +2,10 @@ package efub.cpbr.crumble.global.exception;
 
 import efub.cpbr.crumble.global.exception.dto.ErrorDto;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -21,5 +23,22 @@ public class GlobalExceptionHandler{
                 request.getRequestURI()
         );
         return new ResponseEntity<>(errorDto, HttpStatusCode.valueOf(e.getErrorCode().getStatus()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorDto> handleValidationException(MethodArgumentNotValidException e, HttpServletRequest request) {
+        String errorMessage = e.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(error -> error.getDefaultMessage())
+                .orElse("입력값이 올바르지 않습니다.");
+        ErrorDto errorDto = new ErrorDto(
+                "VALIDATION_FAILED",
+                LocalDateTime.now().toString(),
+                errorMessage,
+                HttpStatus.BAD_REQUEST.value(),
+                request.getRequestURI()
+        );
+        return new ResponseEntity<>(errorDto, HttpStatusCode.valueOf(HttpStatus.BAD_REQUEST.value()));
+
     }
 }

--- a/src/main/java/efub/cpbr/crumble/question/service/QuestionService.java
+++ b/src/main/java/efub/cpbr/crumble/question/service/QuestionService.java
@@ -18,8 +18,12 @@ public class QuestionService {
 
     @Transactional(readOnly = true)
     public QuestionResponse getQuestion(LocalDate date) {
-        Question question = questionRepository.findByDate(date).
+        return QuestionResponse.from(findQuestionByIdOrThrow(date));
+    }
+
+    @Transactional(readOnly = true)
+    public Question findQuestionByIdOrThrow(LocalDate date) {
+        return questionRepository.findByDate(date).
                 orElseThrow(() -> new CustomException(ErrorCode.QUESTION_NOT_FOUND));
-        return QuestionResponse.from(question);
     }
 }


### PR DESCRIPTION
## 🔧 작업 사항(Summary)<!--- 진행한 작업에 대해 설명해주세요. -->
- [x] date 기반 question 조회 별도 메서드로 분리
- [x] Answer 생성/조회 api  (※ JWT 관련 어노테이션은 주석 처리해둔 상태입니다.)
- [x] Valid 어노테이션 관련 에러 핸들링 추가 

## ✨ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정


## ✅ To-do (선택)
<!--- 작업 예정인 테스크를 작성해 주세요. --->
- [ ] JWT 적용 이후 @AuthenticationPrincipal 적용 예정
- [ ]  인증 로직 적용 후 테스트 추가 예정


## 기타
- 답변 최소 글자 수 검증은 `@Size(min = 50)` 어노테이션으로 처리
- 유효성 검증 에러도 ErrorDto 형식으로 반환되도록 추가


## 📌 Issue Number<!--- ex) #이슈이름, #이슈번호 -->
- #3 
- closes #1 

