### PR TITLE
[REFACTOR] 캘린더, 포춘쿠키 api의 User 파라미터, LocalDate 메서드 분리 및 Swagger 작성

### DIFF
--- a/src/main/java/efub/cpbr/crumble/calendar/controller/CalendarController.java
+++ b/src/main/java/efub/cpbr/crumble/calendar/controller/CalendarController.java
@@ -4,6 +4,10 @@ import efub.cpbr.crumble.calendar.dto.AnswerDto;
 import efub.cpbr.crumble.calendar.dto.AnsweredDatesResponse;
 import efub.cpbr.crumble.calendar.service.CalendarService;
 import efub.cpbr.crumble.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,27 +24,55 @@ public class CalendarController {
 
     private final CalendarService calendarService;
 
-    // 캘린더에서 월별로 답변한 날짜를 조회
+    // 캘린더에서 월별로 답변한 날짜 조회 컨트롤러
+    @Operation(
+            summary = "포춘 쿠키 열기",
+            description = "하루에 1번 과거의 랜덤 답변을 조회합니다.."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 정보 없음")
+    })
     @GetMapping("/calendar/answers")
     public ResponseEntity<AnsweredDatesResponse> getAnsweredDates(//@AuthenticationPrincipal
                                                                   User user,
-                                                                  @RequestParam int year,
-                                                                  @RequestParam int month){
+                                                                  @Parameter(description = "조회 연도", example = "2025")
+                                                                      @RequestParam int year,
+                                                                  @Parameter(description = "조회 월", example = "3")
+                                                                      @RequestParam int month){
         return ResponseEntity.ok(calendarService.getAnsweredDates(user, year, month));
     }
 
     // 월별 답변 목록을 조회
+    @Operation(
+            summary = "포춘 쿠키 열기",
+            description = "하루에 1번 과거의 랜덤 답변을 조회합니다.."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 정보 없음")
+    })
     @GetMapping("/answers/me")
     public ResponseEntity<List<AnswerDto>> getMonthlyAnswers(//@AuthenticationPrincipal
                                                              User user,
-                                                             @RequestParam int year,
-                                                             @RequestParam int month
+                                                             @Parameter(description = "조회 연도", example = "2025")
+                                                                 @RequestParam int year,
+                                                             @Parameter(description = "조회 월", example = "3")
+                                                                 @RequestParam int month
     ) {
         List<AnswerDto> answerList = calendarService.getMonthlyAnswers(user, year, month);
         return ResponseEntity.ok(answerList);
     }
 
     // 연속 일수 조회
+    @Operation(
+            summary = "포춘 쿠키 열기",
+            description = "하루에 1번 과거의 랜덤 답변을 조회합니다.."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 정보 없음")
+    })
     @GetMapping("/answers/streak")
     public ResponseEntity<Integer> getStreak(//@AuthenticationPrincipal
                                              User user) {
@@ -48,12 +80,22 @@ public class CalendarController {
         return ResponseEntity.ok(streak);
     }
 
+    @Operation(
+            summary = "포춘 쿠키 열기",
+            description = "하루에 1번 과거의 랜덤 답변을 조회합니다.."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 정보 없음")
+    })
     //쿠키 개수 조회
     @GetMapping("/cookies")
     public ResponseEntity<Integer> getMonthlyCookieCount(//@AuthenticationPrincipal
                                                          User user,
-                                                         @RequestParam int year,
-                                                         @RequestParam int month
+                                                         @Parameter(description = "조회 연도", example = "2025")
+                                                             @RequestParam int year,
+                                                         @Parameter(description = "조회 월", example = "3")
+                                                             @RequestParam int month
     ) {
         int cookieCount = calendarService.getMonthlyCookieCount(user, year, month);
         return ResponseEntity.ok(cookieCount);

--- a/src/main/java/efub/cpbr/crumble/calendar/controller/CalendarController.java
+++ b/src/main/java/efub/cpbr/crumble/calendar/controller/CalendarController.java
@@ -3,13 +3,13 @@ package efub.cpbr.crumble.calendar.controller;
 import efub.cpbr.crumble.calendar.dto.AnswerDto;
 import efub.cpbr.crumble.calendar.dto.AnsweredDatesResponse;
 import efub.cpbr.crumble.calendar.service.CalendarService;
+import efub.cpbr.crumble.user.entity.User;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+//import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -22,35 +22,40 @@ public class CalendarController {
 
     // 캘린더에서 월별로 답변한 날짜를 조회
     @GetMapping("/calendar/answers")
-    public ResponseEntity<AnsweredDatesResponse> getAnsweredDates(@RequestParam int year,
+    public ResponseEntity<AnsweredDatesResponse> getAnsweredDates(//@AuthenticationPrincipal
+                                                                  User user,
+                                                                  @RequestParam int year,
                                                                   @RequestParam int month){
-        return ResponseEntity.ok(calendarService.getAnsweredDates(year, month));
+        return ResponseEntity.ok(calendarService.getAnsweredDates(user, year, month));
     }
 
     // 월별 답변 목록을 조회
     @GetMapping("/answers/me")
-    public ResponseEntity<List<AnswerDto>> getMonthlyAnswers(
-            @RequestParam int year,
-            @RequestParam int month
+    public ResponseEntity<List<AnswerDto>> getMonthlyAnswers(//@AuthenticationPrincipal
+                                                             User user,
+                                                             @RequestParam int year,
+                                                             @RequestParam int month
     ) {
-        List<AnswerDto> answerList = calendarService.getMonthlyAnswers(year, month);
+        List<AnswerDto> answerList = calendarService.getMonthlyAnswers(user, year, month);
         return ResponseEntity.ok(answerList);
     }
 
     // 연속 일수 조회
     @GetMapping("/answers/streak")
-    public ResponseEntity<Integer> getStreak() {
-        int streak = calendarService.getStreak();
+    public ResponseEntity<Integer> getStreak(//@AuthenticationPrincipal
+                                             User user) {
+        int streak = calendarService.getStreak(user);
         return ResponseEntity.ok(streak);
     }
 
     //쿠키 개수 조회
     @GetMapping("/cookies")
-    public ResponseEntity<Integer> getMonthlyCookieCount(
-            @RequestParam int year,
-            @RequestParam int month
+    public ResponseEntity<Integer> getMonthlyCookieCount(//@AuthenticationPrincipal
+                                                         User user,
+                                                         @RequestParam int year,
+                                                         @RequestParam int month
     ) {
-        int cookieCount = calendarService.getMonthlyCookieCount(year, month);
+        int cookieCount = calendarService.getMonthlyCookieCount(user, year, month);
         return ResponseEntity.ok(cookieCount);
     }
 

--- a/src/main/java/efub/cpbr/crumble/calendar/service/CalendarService.java
+++ b/src/main/java/efub/cpbr/crumble/calendar/service/CalendarService.java
@@ -3,6 +3,8 @@ package efub.cpbr.crumble.calendar.service;
 import efub.cpbr.crumble.calendar.dto.AnswerDto;
 import efub.cpbr.crumble.calendar.dto.AnsweredDatesResponse;
 import efub.cpbr.crumble.calendar.repository.CalendarRepository;
+import efub.cpbr.crumble.global.exception.CustomException;
+import efub.cpbr.crumble.global.exception.ErrorCode;
 import efub.cpbr.crumble.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,8 +27,10 @@ public class CalendarService {
     //private final UserService userService;
 
     // 해당 년월에 작성한 답변 일수 목록
-    public AnsweredDatesResponse getAnsweredDates(int year, int month){
-        //User user = userService.getCurrentUser();
+    public AnsweredDatesResponse getAnsweredDates(User user, int year, int month){
+        if (user == null) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
         //Long userId = user.getId();
         Long userId = 1L; //임시
 
@@ -47,8 +51,10 @@ public class CalendarService {
     }
 
     // 월별 답변 목록
-    public List<AnswerDto> getMonthlyAnswers(int year, int month) {
-        //User user = userService.getCurrentUser();
+    public List<AnswerDto> getMonthlyAnswers(User user, int year, int month) {
+        if (user == null) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
         //Long userId = user.getId();
         Long userId = 1L; //임시
 
@@ -62,8 +68,10 @@ public class CalendarService {
     }
 
     // 연속 일수
-    public int getStreak() {
-        //User user = userService.getCurrentUser();
+    public int getStreak(User user) {
+        if (user == null) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
         //Long userId = user.getId();
         Long userId = 1L; //임시
 
@@ -84,8 +92,10 @@ public class CalendarService {
     }
 
     //쿠키 조회
-    public int getMonthlyCookieCount(int year, int month) {
-        //User user = userService.getCurrentUser();
+    public int getMonthlyCookieCount(User user, int year, int month) {
+        if (user == null) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
         //Long userId = user.getId();
         Long userId = 1L; //임시
 

--- a/src/main/java/efub/cpbr/crumble/calendar/service/CalendarService.java
+++ b/src/main/java/efub/cpbr/crumble/calendar/service/CalendarService.java
@@ -34,13 +34,8 @@ public class CalendarService {
         //Long userId = user.getId();
         Long userId = 1L; //임시
 
-        LocalDate start = LocalDate.of(year, month, 1);
-        LocalDate end = start.withDayOfMonth(start.lengthOfMonth());
-        LocalDateTime startDateTime = start.atStartOfDay();
-        LocalDateTime endDateTime = end.atTime(LocalTime.MAX);
-
-        List<LocalDateTime> answerTimes = calendarRepository.findAnsweredDatesInMonth(userId, startDateTime, endDateTime);
-        //userId 대신 user.getId()
+        LocalDateTime[] range = getMonthDateTimeRange(year, month); //월의 시작 시간, 끝 시간
+        List<LocalDateTime> answerTimes = calendarRepository.findAnsweredDatesInMonth(userId, range[0], range[1]);
 
         List<LocalDate> answeredDates =  answerTimes.stream()
                 .map(LocalDateTime::toLocalDate)
@@ -58,13 +53,8 @@ public class CalendarService {
         //Long userId = user.getId();
         Long userId = 1L; //임시
 
-        // 1일 00:00:00
-        LocalDateTime start = LocalDate.of(year, month, 1).atStartOfDay();
-
-        // 해당 월 마지막날 23:59:59
-        LocalDateTime end = start.withDayOfMonth(start.toLocalDate().lengthOfMonth()).withHour(23).withMinute(59).withSecond(59);
-
-        return calendarRepository.findMonthlyAnswers(userId, start, end);
+        LocalDateTime[] range = getMonthDateTimeRange(year, month);
+        return calendarRepository.findMonthlyAnswers(userId, range[0], range[1]);
     }
 
     // 연속 일수
@@ -99,14 +89,13 @@ public class CalendarService {
         //Long userId = user.getId();
         Long userId = 1L; //임시
 
-        LocalDate start = LocalDate.of(year, month, 1);
-        LocalDate end = start.withDayOfMonth(start.lengthOfMonth());
+        LocalDateTime[] range = getMonthDateTimeRange(year, month);
 
         // createdAt을 LocalDate로 뽑기
         List<LocalDate> answerDates = calendarRepository.findAnsweredDatesInMonth(
                         userId,
-                        start.atStartOfDay(),
-                        end.atTime(23, 59, 59)
+                        range[0],
+                        range[1]
                 ).stream()
                 .map(LocalDateTime::toLocalDate)
                 .toList();
@@ -125,6 +114,17 @@ public class CalendarService {
 
         return (int) cookieCount;
     }
+
+    //월의 1일, 말일 구하는 메서드
+    private LocalDateTime[] getMonthDateTimeRange(int year, int month) {
+        LocalDate start = LocalDate.of(year, month, 1);
+        LocalDate end = start.withDayOfMonth(start.lengthOfMonth());
+        return new LocalDateTime[] {
+                start.atStartOfDay(),
+                end.atTime(LocalTime.MAX)
+        };
+    }
+
 
 
 }

--- a/src/main/java/efub/cpbr/crumble/item/controller/FortuneController.java
+++ b/src/main/java/efub/cpbr/crumble/item/controller/FortuneController.java
@@ -4,6 +4,9 @@ import efub.cpbr.crumble.item.dto.FortuneAnswerResponse;
 import efub.cpbr.crumble.item.dto.FortuneUseCheckResponse;
 import efub.cpbr.crumble.item.service.FortuneService;
 import efub.cpbr.crumble.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,12 +21,32 @@ public class FortuneController {
 
     private final FortuneService fortuneService;
 
+    //포춘쿠키 조회 컨트롤러
+    @Operation(
+            summary = "포춘 쿠키 열기",
+            description = "하루에 1번 과거의 랜덤 답변을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 정보 없음"),
+            @ApiResponse(responseCode = "403", description = "이미 포춘쿠키 사용함"),
+            @ApiResponse(responseCode = "404", description = "과거의 답변 존재하지 않음")
+    })
     @GetMapping
     public ResponseEntity<FortuneAnswerResponse> getFortune(//@AuthenticationPrincipal
                                                             User user) {
         return ResponseEntity.ok(fortuneService.getFortune(user));
     }
 
+    //포춘쿠키 존재 여부 확인 컨트롤러
+    @Operation(
+            summary = "포춘 쿠키 여부 확인",
+            description = "오늘의 포춘쿠키가 남아있는지 확인합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 정보 없음")
+    })
     @GetMapping("/used")
     public ResponseEntity<FortuneUseCheckResponse> checkTodayUse(//@AuthenticationPrincipal
                                                                  User user) {

--- a/src/main/java/efub/cpbr/crumble/item/controller/FortuneController.java
+++ b/src/main/java/efub/cpbr/crumble/item/controller/FortuneController.java
@@ -3,6 +3,7 @@ package efub.cpbr.crumble.item.controller;
 import efub.cpbr.crumble.item.dto.FortuneAnswerResponse;
 import efub.cpbr.crumble.item.dto.FortuneUseCheckResponse;
 import efub.cpbr.crumble.item.service.FortuneService;
+import efub.cpbr.crumble.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,13 +19,15 @@ public class FortuneController {
     private final FortuneService fortuneService;
 
     @GetMapping
-    public ResponseEntity<FortuneAnswerResponse> getFortune() {
-        return ResponseEntity.ok(fortuneService.getFortune());
+    public ResponseEntity<FortuneAnswerResponse> getFortune(//@AuthenticationPrincipal
+                                                            User user) {
+        return ResponseEntity.ok(fortuneService.getFortune(user));
     }
 
     @GetMapping("/used")
-    public ResponseEntity<FortuneUseCheckResponse> checkTodayUse() {
-        return ResponseEntity.ok(fortuneService.checkTodayUse());
+    public ResponseEntity<FortuneUseCheckResponse> checkTodayUse(//@AuthenticationPrincipal
+                                                                 User user) {
+        return ResponseEntity.ok(fortuneService.checkTodayUse(user));
     }
 
 }

--- a/src/main/java/efub/cpbr/crumble/item/service/FortuneService.java
+++ b/src/main/java/efub/cpbr/crumble/item/service/FortuneService.java
@@ -27,8 +27,10 @@ public class FortuneService {
     private static final Duration TTL = Duration.ofDays(1);
 
     //포춘쿠키로 랜덤 답변 조회
-    public FortuneAnswerResponse getFortune() {
-        //User user = userService.getCurrentUser();
+    public FortuneAnswerResponse getFortune(User user) {
+        if (user == null) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
         //Long userId = user.getId();
         Long userId = 1L; //임시
 
@@ -54,8 +56,6 @@ public class FortuneService {
         );
 
         // 사용자 포인트 증가
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         user.addPoint(10L);
 
         // Redis에 사용 기록 저장
@@ -65,8 +65,10 @@ public class FortuneService {
     }
 
     //오늘의 포춘쿠키 사용 여부 조회
-    public FortuneUseCheckResponse checkTodayUse() {
-        //User user = userService.getCurrentUser();
+    public FortuneUseCheckResponse checkTodayUse(User user) {
+        if (user == null) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
         //Long userId = user.getId();
         Long userId = 1L; //임시
 


### PR DESCRIPTION
## 🔧 작업 사항(Summary)<!--- 진행한 작업에 대해 설명해주세요. -->
- [x] 캘린더 Controller를 `@AuthenticationPrincipal User user` 파라미터 형식으로 변경
- [x] 포춘쿠키 Controller를 `@AuthenticationPrincipal User user` 파라미터 형식으로 변경
- [x] 캘린더, 포춘쿠키 api Swagger 작성
- [x] Calendar Service의 `LocalDateTime[] getMonthDateTimeRange` 메서드 분리

## ✨ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ✅ To-do (선택)
<!--- 작업 예정인 테스크를 작성해 주세요. --->
- [ ] user 연동
- [ ] text code 작성


## 📸 스크린샷 or Test 결과 (선택)
<img width="1788" height="590" alt="image" src="https://github.com/user-attachments/assets/6b5e471e-f0dc-4948-bab6-fc2608e6e904" />
<img width="1795" height="827" alt="image" src="https://github.com/user-attachments/assets/0440d8f5-97ed-490e-a1ab-fa2e0aeefc32" />



## 📌 Issue Number<!--- ex) #이슈이름, #이슈번호 -->
feat #14 
feat #16 


