### PR TITLE
[FEAT] 질문+힌트 자동 생성 스케줄러 및 힌트 조회 api 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+    implementation 'dev.langchain4j:langchain4j:1.0.1'
+    implementation 'dev.langchain4j:langchain4j-open-ai:1.0.1'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/efub/cpbr/crumble/CrumbleApplication.java
+++ b/src/main/java/efub/cpbr/crumble/CrumbleApplication.java
@@ -2,8 +2,10 @@ package efub.cpbr.crumble;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class CrumbleApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/efub/cpbr/crumble/answer/controller/AnswerController.java
+++ b/src/main/java/efub/cpbr/crumble/answer/controller/AnswerController.java
@@ -20,7 +20,7 @@ import java.time.LocalDate;
 @Tag(name = "Answer", description = "답변 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/question/{date}/answer")
+@RequestMapping("/questions/{date}/answer")
 public class AnswerController {
 
     private final AnswerService answerService;

--- a/src/main/java/efub/cpbr/crumble/global/exception/ErrorCode.java
+++ b/src/main/java/efub/cpbr/crumble/global/exception/ErrorCode.java
@@ -10,8 +10,10 @@ public enum ErrorCode {
     UNAUTHORIZED_ACCESS(401, "인증되지 않은 사용자입니다."),
 
     // Question 관련 에러
-    AI_GENERATION_FAILED(500, "AI 질문 생성 중 오류가 발생했습니다."),
+    AI_QUESTION_GENERATION_FAILED(500, "AI 질문 생성 중 오류가 발생했습니다."),
     QUESTION_NOT_FOUND(404, "해당 날짜의 질문이 존재하지 않습니다."),
+    // Hint 관련 에러
+    AI_HINT_GENERATION_FAILED(500,"AI 힌트 생성 중 오류가 발생했습니다."),
     // Answer 관련 에러
     ANSWER_NOT_FOUND(404, "해당 답변이 존재하지 않습니다."),
 

--- a/src/main/java/efub/cpbr/crumble/global/exception/ErrorCode.java
+++ b/src/main/java/efub/cpbr/crumble/global/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     UNAUTHORIZED_ACCESS(401, "인증되지 않은 사용자입니다."),
 
     // Question 관련 에러
+    AI_GENERATION_FAILED(500, "AI 질문 생성 중 오류가 발생했습니다."),
     QUESTION_NOT_FOUND(404, "해당 날짜의 질문이 존재하지 않습니다.");
 
     private final int status;

--- a/src/main/java/efub/cpbr/crumble/global/exception/ErrorCode.java
+++ b/src/main/java/efub/cpbr/crumble/global/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     QUESTION_NOT_FOUND(404, "해당 날짜의 질문이 존재하지 않습니다."),
     // Hint 관련 에러
     AI_HINT_GENERATION_FAILED(500,"AI 힌트 생성 중 오류가 발생했습니다."),
+    HINT_NOT_FOUND(404, "해당 날짜의 질문에 대한 힌트가 존재하지 않습니다."),
     // Answer 관련 에러
     ANSWER_NOT_FOUND(404, "해당 답변이 존재하지 않습니다."),
 

--- a/src/main/java/efub/cpbr/crumble/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/efub/cpbr/crumble/global/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler{
@@ -17,7 +18,7 @@ public class GlobalExceptionHandler{
     protected ResponseEntity<ErrorDto> handleCustomException(CustomException e, HttpServletRequest request) {
         ErrorDto errorDto = new ErrorDto(
                 e.getErrorCode().name(),
-                LocalDateTime.now().toString(),
+                LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME),
                 e.getErrorCode().getMessage(),
                 e.getErrorCode().getStatus(),
                 request.getRequestURI()
@@ -33,12 +34,11 @@ public class GlobalExceptionHandler{
                 .orElse("입력값이 올바르지 않습니다.");
         ErrorDto errorDto = new ErrorDto(
                 "VALIDATION_FAILED",
-                LocalDateTime.now().toString(),
+                LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME),
                 errorMessage,
                 HttpStatus.BAD_REQUEST.value(),
                 request.getRequestURI()
         );
-        return new ResponseEntity<>(errorDto, HttpStatusCode.valueOf(HttpStatus.BAD_REQUEST.value()));
-
+        return new ResponseEntity<>(errorDto, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/efub/cpbr/crumble/hint/controller/HintController.java
+++ b/src/main/java/efub/cpbr/crumble/hint/controller/HintController.java
@@ -19,7 +19,7 @@ import java.time.LocalDate;
 @Tag(name = "Hint", description = "힌트 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/question/{date}/hints")
+@RequestMapping("/questions/{date}/hints")
 class HintController {
     private final HintService hintService;
 

--- a/src/main/java/efub/cpbr/crumble/hint/controller/HintController.java
+++ b/src/main/java/efub/cpbr/crumble/hint/controller/HintController.java
@@ -2,7 +2,10 @@ package efub.cpbr.crumble.hint.controller;
 
 import efub.cpbr.crumble.hint.dto.res.HintListResponse;
 import efub.cpbr.crumble.hint.service.HintService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +23,14 @@ import java.time.LocalDate;
 class HintController {
     private final HintService hintService;
 
+    @Operation(
+            summary = "특정 날짜의 질문에 대한 힌트 3개 조회",
+            description = "날짜(yyyy-MM-dd)의 질문에 대한 힌트 리스트를 조회합니다.."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "질문 or 힌트없음")
+    })
     @GetMapping
     public ResponseEntity<HintListResponse> getHints(@Parameter(description = "질문 날짜", example = "2024-07-17") @PathVariable LocalDate date){
         return ResponseEntity.ok(hintService.getHints(date));

--- a/src/main/java/efub/cpbr/crumble/hint/controller/HintController.java
+++ b/src/main/java/efub/cpbr/crumble/hint/controller/HintController.java
@@ -1,0 +1,27 @@
+package efub.cpbr.crumble.hint.controller;
+
+import efub.cpbr.crumble.hint.dto.res.HintListResponse;
+import efub.cpbr.crumble.hint.service.HintService;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@Tag(name = "Hint", description = "힌트 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/question/{date}/hints")
+class HintController {
+    private final HintService hintService;
+
+    @GetMapping
+    public ResponseEntity<HintListResponse> getHints(@Parameter(description = "질문 날짜", example = "2024-07-17") @PathVariable LocalDate date){
+        return ResponseEntity.ok(hintService.getHints(date));
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/hint/controller/HintController.java
+++ b/src/main/java/efub/cpbr/crumble/hint/controller/HintController.java
@@ -20,7 +20,7 @@ import java.time.LocalDate;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/questions/{date}/hints")
-class HintController {
+public class HintController {
     private final HintService hintService;
 
     @Operation(

--- a/src/main/java/efub/cpbr/crumble/hint/dto/res/HintListResponse.java
+++ b/src/main/java/efub/cpbr/crumble/hint/dto/res/HintListResponse.java
@@ -1,0 +1,15 @@
+package efub.cpbr.crumble.hint.dto.res;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import efub.cpbr.crumble.hint.entity.Hint;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record HintListResponse(@JsonProperty("question_id")Long questionId,
+                               List<HintResponse> hints) {
+    public static HintListResponse from(Long questionId, List<Hint> hints) {
+        List<HintResponse> hintResponses = hints.stream().map(HintResponse::from).collect(Collectors.toList());
+        return new HintListResponse(questionId, hintResponses);
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/hint/dto/res/HintResponse.java
+++ b/src/main/java/efub/cpbr/crumble/hint/dto/res/HintResponse.java
@@ -1,0 +1,11 @@
+package efub.cpbr.crumble.hint.dto.res;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import efub.cpbr.crumble.hint.entity.Hint;
+
+public record HintResponse(@JsonProperty("hint_id")Long hintId,
+                           String content) {
+    public static HintResponse from(Hint hint){
+        return new HintResponse(hint.getId(), hint.getContent());
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/hint/entity/Hint.java
+++ b/src/main/java/efub/cpbr/crumble/hint/entity/Hint.java
@@ -1,0 +1,24 @@
+package efub.cpbr.crumble.hint.entity;
+
+import efub.cpbr.crumble.question.entity.Question;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(toBuilder = true)
+public class Hint {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="hint_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "question_id", nullable = false)
+    private Question question;
+}

--- a/src/main/java/efub/cpbr/crumble/hint/repository/HintRepository.java
+++ b/src/main/java/efub/cpbr/crumble/hint/repository/HintRepository.java
@@ -1,7 +1,11 @@
 package efub.cpbr.crumble.hint.repository;
 
 import efub.cpbr.crumble.hint.entity.Hint;
+import efub.cpbr.crumble.question.entity.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface HintRepository extends JpaRepository<Hint, Long> {
+    List<Hint> findAllByQuestion(Question question);
 }

--- a/src/main/java/efub/cpbr/crumble/hint/repository/HintRepository.java
+++ b/src/main/java/efub/cpbr/crumble/hint/repository/HintRepository.java
@@ -1,0 +1,7 @@
+package efub.cpbr.crumble.hint.repository;
+
+import efub.cpbr.crumble.hint.entity.Hint;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HintRepository extends JpaRepository<Hint, Long> {
+}

--- a/src/main/java/efub/cpbr/crumble/hint/service/HintAIService.java
+++ b/src/main/java/efub/cpbr/crumble/hint/service/HintAIService.java
@@ -15,9 +15,10 @@ import java.util.List;
 public class HintAIService {
 
     private final OpenAiChatModel openAiChatModel;
+    private final ObjectMapper objectMapper;
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
-    public HintAIService(@Value("${openai.api-key}") String apiKey) {
+    public HintAIService(@Value("${openai.api-key}") String apiKey,ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
         this.openAiChatModel = OpenAiChatModel.builder()
                 .apiKey(apiKey)
                 .modelName("gpt-4o-mini")

--- a/src/main/java/efub/cpbr/crumble/hint/service/HintAIService.java
+++ b/src/main/java/efub/cpbr/crumble/hint/service/HintAIService.java
@@ -1,0 +1,63 @@
+package efub.cpbr.crumble.hint.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import efub.cpbr.crumble.global.exception.CustomException;
+import efub.cpbr.crumble.global.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+public class HintAIService {
+
+    private final OpenAiChatModel openAiChatModel;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    public HintAIService(@Value("${openai.api-key}") String apiKey) {
+        this.openAiChatModel = OpenAiChatModel.builder()
+                .apiKey(apiKey)
+                .modelName("gpt-4o-mini")
+                .temperature(0.7)
+                .build();
+    }
+    public List<String> generateHints(String questionText, int hintCount) {
+        String prompt =
+                "You are an English writing coach. For the following daily question:\n" +
+                        "\"" + questionText + "\"\n" +
+                        "Generate " + hintCount + " concise single-word hints (nouns only) useful for answering this question. "+
+                        "Respond with a JSON array of strings only, no explanation or extra text.";        ;
+        try {
+            return parseHintsFromJsonArray(openAiChatModel.chat(prompt));
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.AI_HINT_GENERATION_FAILED);
+        }
+    }
+
+    private List<String> parseHintsFromJsonArray(String jsonResponse) {
+        try{
+            // 1. 백틱 코드 블럭 등 제거
+            String cleaned = jsonResponse
+                    .replaceAll("^```json\\s*", "")  // ```
+                    .replaceAll("^```\\s*", "")       // ```
+                    .replaceAll("```$", "")           // 코드블록 끝 제거
+                    .replaceAll("^`", "")             // 단일 백틱 제거
+                    .replaceAll("`$", "")             // 단일 백틱 제거
+                    .trim();
+            // 2. 대괄호 포함된 JSON 배열 부분만 추출(단순 패턴, 더 정교하게 가능)
+            int startIdx = cleaned.indexOf('[');
+            int endIdx = cleaned.lastIndexOf(']');
+            if (startIdx >= 0 && endIdx > startIdx) {
+                cleaned = cleaned.substring(startIdx, endIdx + 1);
+            }
+            // 3. 파싱 시도
+            return objectMapper.readValue(cleaned, new TypeReference<List<String>>() {});
+        }catch (Exception e){
+            e.printStackTrace();
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/hint/service/HintService.java
+++ b/src/main/java/efub/cpbr/crumble/hint/service/HintService.java
@@ -35,7 +35,7 @@ public class HintService {
 
     @Transactional(readOnly = true)
     public HintListResponse getHints(LocalDate date) {
-        Question question = questionService.findQuestionByIdOrThrow(date);
+        Question question = questionService.findQuestionByDateOrThrow(date);
         List<Hint> hints = hintRepository.findAllByQuestion(question);
         if (hints.isEmpty()) {
             throw new CustomException(ErrorCode.HINT_NOT_FOUND);

--- a/src/main/java/efub/cpbr/crumble/hint/service/HintService.java
+++ b/src/main/java/efub/cpbr/crumble/hint/service/HintService.java
@@ -1,12 +1,15 @@
 package efub.cpbr.crumble.hint.service;
 
+import efub.cpbr.crumble.hint.dto.res.HintListResponse;
 import efub.cpbr.crumble.hint.entity.Hint;
 import efub.cpbr.crumble.hint.repository.HintRepository;
 import efub.cpbr.crumble.question.entity.Question;
+import efub.cpbr.crumble.question.service.QuestionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -14,6 +17,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class HintService {
     private final HintRepository hintRepository;
+    private final QuestionService questionService;
 
     @Transactional
     public void saveHints(Question question, List<String> hints) {
@@ -25,5 +29,13 @@ public class HintService {
                         .build())
                 .collect(Collectors.toList());
         hintRepository.saveAll(hintEntities);
+    }
+
+    @Transactional(readOnly = true)
+    public HintListResponse getHints(LocalDate date) {
+        Question question = questionService.findQuestionByIdOrThrow(date);
+        List<Hint> hints = hintRepository.findAllByQuestion(question);
+
+        return HintListResponse.from(question.getId(),hints);
     }
 }

--- a/src/main/java/efub/cpbr/crumble/hint/service/HintService.java
+++ b/src/main/java/efub/cpbr/crumble/hint/service/HintService.java
@@ -1,5 +1,7 @@
 package efub.cpbr.crumble.hint.service;
 
+import efub.cpbr.crumble.global.exception.CustomException;
+import efub.cpbr.crumble.global.exception.ErrorCode;
 import efub.cpbr.crumble.hint.dto.res.HintListResponse;
 import efub.cpbr.crumble.hint.entity.Hint;
 import efub.cpbr.crumble.hint.repository.HintRepository;
@@ -35,7 +37,9 @@ public class HintService {
     public HintListResponse getHints(LocalDate date) {
         Question question = questionService.findQuestionByIdOrThrow(date);
         List<Hint> hints = hintRepository.findAllByQuestion(question);
-
+        if (hints.isEmpty()) {
+            throw new CustomException(ErrorCode.HINT_NOT_FOUND);
+        }
         return HintListResponse.from(question.getId(),hints);
     }
 }

--- a/src/main/java/efub/cpbr/crumble/hint/service/HintService.java
+++ b/src/main/java/efub/cpbr/crumble/hint/service/HintService.java
@@ -1,0 +1,29 @@
+package efub.cpbr.crumble.hint.service;
+
+import efub.cpbr.crumble.hint.entity.Hint;
+import efub.cpbr.crumble.hint.repository.HintRepository;
+import efub.cpbr.crumble.question.entity.Question;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class HintService {
+    private final HintRepository hintRepository;
+
+    @Transactional
+    public void saveHints(Question question, List<String> hints) {
+        List<Hint> hintEntities = hints.stream()
+                .filter(hintContent -> hintContent != null && !hintContent.trim().isEmpty())
+                .map(hintContent -> Hint.builder()
+                        .question(question)
+                        .content(hintContent.trim())
+                        .build())
+                .collect(Collectors.toList());
+        hintRepository.saveAll(hintEntities);
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/question/QuestionGenerateScheduler.java
+++ b/src/main/java/efub/cpbr/crumble/question/QuestionGenerateScheduler.java
@@ -1,5 +1,8 @@
 package efub.cpbr.crumble.question;
 
+import efub.cpbr.crumble.hint.service.HintAIService;
+import efub.cpbr.crumble.hint.service.HintService;
+import efub.cpbr.crumble.question.entity.Question;
 import efub.cpbr.crumble.question.service.QuestionAIService;
 import efub.cpbr.crumble.question.entity.QuestionCategory;
 import efub.cpbr.crumble.question.service.QuestionService;
@@ -8,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Random;
 
 @Slf4j
@@ -16,24 +20,32 @@ import java.util.Random;
 public class QuestionGenerateScheduler {
     private final QuestionAIService questionAIService;
     private final QuestionService questionService;
+    private final HintService hintService;
+    private final HintAIService hintAIService;
 
     //@Scheduled(cron = "0 00 23 * * ?", zone = "Asia/Seoul")
-    //@Scheduled(cron = "0 * * * * ?", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 * * * * ?", zone = "Asia/Seoul")
     public void createRandomCategoryQuestion(){
         log.info("질문 생성 스케줄 시작");
         int maxRetries = 3;// 최대 재시도 수
 
-        for(int attempt = 1; attempt < maxRetries; attempt++){
+        for(int attempt = 1; attempt <= maxRetries; attempt++){
             try {
                 QuestionCategory[] categories = QuestionCategory.values();
                 QuestionCategory randomCategory = categories[new Random().nextInt(categories.length)];
 
+                // 질문 생성
                 String questionContent = questionAIService.generateQuestionForCategory(randomCategory);
 
-                // 유사도 검사
-                if (!questionService.isSimilarTextExist(questionContent)) {
-                    questionService.saveQuestion(randomCategory, questionContent);
+                if (!questionService.isSimilarTextExist(questionContent)) {// 유사도 검사
+                    // 질문 저장
+                    Question savedQuestion = questionService.saveQuestion(randomCategory, questionContent);
                     log.info("질문 저장 완료: [{}] {}", randomCategory.name(), questionContent);
+
+                    // 힌트 생성 및 저장
+                    List<String> hints = hintAIService.generateHints(savedQuestion.getContent(), 3);
+                    hintService.saveHints(savedQuestion, hints);
+                    log.info("힌트 3개 저장 완료: 질문ID {}", savedQuestion.getId());
                 } else {
                     log.info("유사 질문 이미 존재: [{}] {}", randomCategory.name(), questionContent);
                 }

--- a/src/main/java/efub/cpbr/crumble/question/QuestionGenerateScheduler.java
+++ b/src/main/java/efub/cpbr/crumble/question/QuestionGenerateScheduler.java
@@ -1,0 +1,50 @@
+package efub.cpbr.crumble.question;
+
+import efub.cpbr.crumble.question.service.QuestionAIService;
+import efub.cpbr.crumble.question.entity.QuestionCategory;
+import efub.cpbr.crumble.question.service.QuestionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class QuestionGenerateScheduler {
+    private final QuestionAIService questionAIService;
+    private final QuestionService questionService;
+
+    //@Scheduled(cron = "0 00 23 * * ?", zone = "Asia/Seoul")
+    //@Scheduled(cron = "0 * * * * ?", zone = "Asia/Seoul")
+    public void createRandomCategoryQuestion(){
+        log.info("질문 생성 스케줄 시작");
+        int maxRetries = 3;// 최대 재시도 수
+
+        for(int attempt = 1; attempt < maxRetries; attempt++){
+            try {
+                QuestionCategory[] categories = QuestionCategory.values();
+                QuestionCategory randomCategory = categories[new Random().nextInt(categories.length)];
+
+                String questionContent = questionAIService.generateQuestionForCategory(randomCategory);
+
+                // 유사도 검사
+                if (!questionService.isSimilarTextExist(questionContent)) {
+                    questionService.saveQuestion(randomCategory, questionContent);
+                    log.info("질문 저장 완료: [{}] {}", randomCategory.name(), questionContent);
+                } else {
+                    log.info("유사 질문 이미 존재: [{}] {}", randomCategory.name(), questionContent);
+                }
+                break;
+            }catch (Exception e){
+                log.error("질문 생성 실패 (시도 {}): {}", attempt, e.getMessage(), e);
+                if (attempt == maxRetries) {
+                    log.error("모든 재시도 실패");
+                    // TODO: 알림 전송
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/question/QuestionGenerateScheduler.java
+++ b/src/main/java/efub/cpbr/crumble/question/QuestionGenerateScheduler.java
@@ -27,12 +27,16 @@ public class QuestionGenerateScheduler {
     //@Scheduled(cron = "0 * * * * ?", zone = "Asia/Seoul")
     public void createRandomCategoryQuestion(){
         log.info("질문 생성 스케줄 시작");
+
+        // Random 객체 생성
+        QuestionCategory[] categories = QuestionCategory.values();
+        Random random = new Random();
+
         int maxRetries = 3;// 최대 재시도 수
 
         for(int attempt = 1; attempt <= maxRetries; attempt++){
             try {
-                QuestionCategory[] categories = QuestionCategory.values();
-                QuestionCategory randomCategory = categories[new Random().nextInt(categories.length)];
+                QuestionCategory randomCategory = categories[random.nextInt(categories.length)];
 
                 // 질문 생성
                 String questionContent = questionAIService.generateQuestionForCategory(randomCategory);
@@ -42,10 +46,24 @@ public class QuestionGenerateScheduler {
                     Question savedQuestion = questionService.saveQuestion(randomCategory, questionContent);
                     log.info("질문 저장 완료: [{}] {}", randomCategory.name(), questionContent);
 
-                    // 힌트 생성 및 저장
-                    List<String> hints = hintAIService.generateHints(savedQuestion.getContent(), 3);
-                    hintService.saveHints(savedQuestion, hints);
-                    log.info("힌트 3개 저장 완료: 질문ID {}", savedQuestion.getId());
+                    // 힌트 생성
+                    int hintRetry = 0;
+                    List<String> hints;
+
+                    do {
+                        hints = hintAIService.generateHints(savedQuestion.getContent(), 3);
+                        hintRetry++;
+                    } while ((hints == null || hints.isEmpty()) && hintRetry < maxRetries);
+
+                    if (hints == null || hints.isEmpty()) {
+                        log.warn("힌트 생성 결과가 없습니다. 질문ID: {}", savedQuestion.getId());
+                        continue;
+                    }
+                    else {
+                        // 힌트 저장
+                        hintService.saveHints(savedQuestion, hints);
+                        log.info("힌트 3개 저장 완료: 질문ID {}", savedQuestion.getId());
+                    }
                 } else {
                     log.info("유사 질문 이미 존재: [{}] {}", randomCategory.name(), questionContent);
                 }
@@ -53,7 +71,7 @@ public class QuestionGenerateScheduler {
             }catch (Exception e){
                 log.error("질문 생성 실패 (시도 {}): {}", attempt, e.getMessage(), e);
                 if (attempt == maxRetries) {
-                    log.error("모든 재시도 실패");
+                    log.error("모든 질문 생성 재시도 실패");
                     // TODO: 알림 전송
                 }
             }

--- a/src/main/java/efub/cpbr/crumble/question/QuestionGenerateScheduler.java
+++ b/src/main/java/efub/cpbr/crumble/question/QuestionGenerateScheduler.java
@@ -24,7 +24,7 @@ public class QuestionGenerateScheduler {
     private final HintAIService hintAIService;
 
     //@Scheduled(cron = "0 00 23 * * ?", zone = "Asia/Seoul")
-    @Scheduled(cron = "0 * * * * ?", zone = "Asia/Seoul")
+    //@Scheduled(cron = "0 * * * * ?", zone = "Asia/Seoul")
     public void createRandomCategoryQuestion(){
         log.info("질문 생성 스케줄 시작");
         int maxRetries = 3;// 최대 재시도 수

--- a/src/main/java/efub/cpbr/crumble/question/controller/QuestionController.java
+++ b/src/main/java/efub/cpbr/crumble/question/controller/QuestionController.java
@@ -4,6 +4,8 @@ import efub.cpbr.crumble.question.dto.res.QuestionResponse;
 import efub.cpbr.crumble.question.service.QuestionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +25,10 @@ public class QuestionController {
             summary = "특정 날짜의 질문 조회",
             description = "날짜(yyyy-MM-dd)별로 질문을 조회합니다."
     )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "질문 없음")
+    })
     @GetMapping("/question/{date}")
     public ResponseEntity<QuestionResponse> getQuestion(
             @Parameter(description = "조회할 날짜 (yyyy-MM-dd)", example = "2025-07-08") @PathVariable LocalDate date) {

--- a/src/main/java/efub/cpbr/crumble/question/controller/QuestionController.java
+++ b/src/main/java/efub/cpbr/crumble/question/controller/QuestionController.java
@@ -29,7 +29,7 @@ public class QuestionController {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "404", description = "질문 없음")
     })
-    @GetMapping("/question/{date}")
+    @GetMapping("/questions/{date}")
     public ResponseEntity<QuestionResponse> getQuestion(
             @Parameter(description = "조회할 날짜 (yyyy-MM-dd)", example = "2025-07-08") @PathVariable LocalDate date) {
         return ResponseEntity.ok(questionService.getQuestion(date));

--- a/src/main/java/efub/cpbr/crumble/question/entity/Question.java
+++ b/src/main/java/efub/cpbr/crumble/question/entity/Question.java
@@ -22,4 +22,8 @@ public class Question {
 
     @Column(nullable = false)
     private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private QuestionCategory category;
 }

--- a/src/main/java/efub/cpbr/crumble/question/entity/QuestionCategory.java
+++ b/src/main/java/efub/cpbr/crumble/question/entity/QuestionCategory.java
@@ -1,0 +1,14 @@
+package efub.cpbr.crumble.question.entity;
+
+public enum QuestionCategory {
+    SCIENCE,
+    HISTORY,
+    IT,
+    MUSIC,
+    SPORTS,
+    LITERATURE,
+    MOVIE,
+    ART,
+    BUSINESS,
+    HEALTH
+}

--- a/src/main/java/efub/cpbr/crumble/question/service/QuestionAIService.java
+++ b/src/main/java/efub/cpbr/crumble/question/service/QuestionAIService.java
@@ -1,0 +1,44 @@
+package efub.cpbr.crumble.question.service;
+
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import efub.cpbr.crumble.global.exception.CustomException;
+import efub.cpbr.crumble.global.exception.ErrorCode;
+import efub.cpbr.crumble.question.entity.QuestionCategory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class QuestionAIService {
+
+    private final OpenAiChatModel openAiChatModel;
+    public QuestionAIService(@Value("${openai.api-key}") String apiKey) {
+        // 생성자에서 LLM 인스턴스 생성(여러 번 쓸 예정이면 싱글턴으로 만들어두는 것이 좋음)
+        this.openAiChatModel = OpenAiChatModel.builder()
+                .apiKey(apiKey)
+                .modelName("gpt-4o-mini")
+                .temperature(0.7)
+                .build();
+    }
+
+    public String generateQuestionForCategory(QuestionCategory category) {
+        // TODO : Prompt 수정
+        String prompt =
+                "You are an English writing coach. " +
+                "Generate a creative and practical open-ended 'daily question' in English for the '" + category.name() + "' category. " +
+                "This question should be designed as a daily writing prompt to inspire the user to reflect on their day or personal experiences. " +
+                "Avoid yes/no questions and focus on questions that encourage storytelling, opinion, or self-reflection. " +
+                "Keep the question within 20 words, suitable for intermediate learners, and provide only one question without any extra explanation or greeting. " +
+                "Here are a few examples of good daily questions: " +
+                "How was your relationship with your friends? " +
+                "What was the most interesting moment you experienced today? " +
+                "What did you learn from a conversation you had recently? " +
+                "Only reply with the final question.";
+        ;
+        try {
+            String questionContent = openAiChatModel.chat(prompt);
+            return questionContent.trim();
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.AI_GENERATION_FAILED);
+        }
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/question/service/QuestionAIService.java
+++ b/src/main/java/efub/cpbr/crumble/question/service/QuestionAIService.java
@@ -38,7 +38,7 @@ public class QuestionAIService {
             String questionContent = openAiChatModel.chat(prompt);
             return questionContent.trim();
         } catch (Exception e) {
-            throw new CustomException(ErrorCode.AI_GENERATION_FAILED);
+            throw new CustomException(ErrorCode.AI_QUESTION_GENERATION_FAILED);
         }
     }
 }

--- a/src/main/java/efub/cpbr/crumble/question/service/QuestionService.java
+++ b/src/main/java/efub/cpbr/crumble/question/service/QuestionService.java
@@ -40,6 +40,7 @@ public class QuestionService {
         return false;
     }
 
+    @Transactional
     public Question saveQuestion(QuestionCategory category, String questionContent) {
         Question question = Question.builder()
                         .category(category)

--- a/src/main/java/efub/cpbr/crumble/question/service/QuestionService.java
+++ b/src/main/java/efub/cpbr/crumble/question/service/QuestionService.java
@@ -40,12 +40,13 @@ public class QuestionService {
         return false;
     }
 
-    public void saveQuestion(QuestionCategory category, String questionContent) {
+    public Question saveQuestion(QuestionCategory category, String questionContent) {
         Question question = Question.builder()
                         .category(category)
                         .content(questionContent)
                         .date(LocalDate.now())
                         .build();
         questionRepository.save(question);
+        return question;
     }
 }

--- a/src/main/java/efub/cpbr/crumble/question/service/QuestionService.java
+++ b/src/main/java/efub/cpbr/crumble/question/service/QuestionService.java
@@ -20,11 +20,11 @@ public class QuestionService {
 
     @Transactional(readOnly = true)
     public QuestionResponse getQuestion(LocalDate date) {
-        return QuestionResponse.from(findQuestionByIdOrThrow(date));
+        return QuestionResponse.from(findQuestionByDateOrThrow(date));
     }
 
     @Transactional(readOnly = true)
-    public Question findQuestionByIdOrThrow(LocalDate date) {
+    public Question findQuestionByDateOrThrow(LocalDate date) {
         return questionRepository.findByDate(date).
                 orElseThrow(() -> new CustomException(ErrorCode.QUESTION_NOT_FOUND));
     }

--- a/src/main/java/efub/cpbr/crumble/question/service/QuestionService.java
+++ b/src/main/java/efub/cpbr/crumble/question/service/QuestionService.java
@@ -4,6 +4,7 @@ import efub.cpbr.crumble.global.exception.CustomException;
 import efub.cpbr.crumble.global.exception.ErrorCode;
 import efub.cpbr.crumble.question.dto.res.QuestionResponse;
 import efub.cpbr.crumble.question.entity.Question;
+import efub.cpbr.crumble.question.entity.QuestionCategory;
 import efub.cpbr.crumble.question.repository.QuestionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,11 +16,32 @@ import java.time.LocalDate;
 @RequiredArgsConstructor
 public class QuestionService {
     private final QuestionRepository questionRepository;
+    //private final EmbeddingStore<Document> vectorStore;
 
     @Transactional(readOnly = true)
     public QuestionResponse getQuestion(LocalDate date) {
         Question question = questionRepository.findByDate(date).
                 orElseThrow(() -> new CustomException(ErrorCode.QUESTION_NOT_FOUND));
         return QuestionResponse.from(question);
+    }
+
+    public boolean isSimilarTextExist(String questionContent) {/*
+        // TODO: 유사 질문 DB/벡터DB에서 검사 (예시로 항상 false 반환)
+        List<Document> documents = vectorStore.similaritySearch(
+                SearchRequest.query(questionContent)
+                        .withSimilarityThreshold(0.8)
+                        .withTopK(1)
+        );
+        */
+        return false;
+    }
+
+    public void saveQuestion(QuestionCategory category, String questionContent) {
+        Question question = Question.builder()
+                        .category(category)
+                        .content(questionContent)
+                        .date(LocalDate.now())
+                        .build();
+        questionRepository.save(question);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,3 +21,6 @@ cors:
   allow-origins:
     - http://localhost:3000
     - http://localhost:5173
+
+openai:
+  api-key: ${API_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,17 @@ spring:
       hibernate:
         format_sql: true
 
+  jwt:
+    secret: ${JWT_KEY}
+    access-token-expiration-millis: 3600000 # 1시간
+    refresh-token-expiration-millis: 604800000 # 7일
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      database: 1
+
 cors:
   allow-origins:
     - http://localhost:3000


### PR DESCRIPTION
## 🔧 작업 사항(Summary)<!--- 진행한 작업에 대해 설명해주세요. -->
- [x] Langchain을 사용해 openAI LLM을 활용한 질문 스케줄러 구현
- [x] 질문 엔티티에 category 필드 추가 
- [x] 생성된 질문에 대해 힌트 LLM 생성 및 저장 
- [x] 힌트 조회 api 

## ✨ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 주석 추가 및 수정


## ✅ To-do (선택)
<!--- 작업 예정인 테스크를 작성해 주세요. --->
- [ ] 질문 중복 유사도 검사


## 기타
- 질문 카테고리 임시로 10개 생성해두었습니다.
- 스케줄러 임시 주석처리해두었습니다. 서버 실행 후 생성되는 질문,힌트에 따라 프롬프트 수정 가능 

## 📸 스크린샷 or Test 결과 (선택)
####  생성된 질문
<img width="1065" height="448" alt="image" src="https://github.com/user-attachments/assets/078d1037-cc38-43e4-97a6-595fc3b6adb2" />

#### 생성된 힌트 
<img width="1076" height="454" alt="image" src="https://github.com/user-attachments/assets/ec49e729-8e53-44da-8618-8f481c34dfd1" />

### 힌트 조회
<img width="686" height="483" alt="image" src="https://github.com/user-attachments/assets/43a206b3-d235-4986-bbfd-b9900928da76" />


## 📌 Issue Number<!--- ex) #이슈이름, #이슈번호 -->
- #9 
