### PR TITLE
[FEAT] login 인증 로직, RedisConfig 및 인증 주입 활성화

### DIFF
--- a/src/main/java/efub/cpbr/crumble/answer/controller/AnswerController.java
+++ b/src/main/java/efub/cpbr/crumble/answer/controller/AnswerController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
@@ -35,8 +36,7 @@ public class AnswerController {
             @ApiResponse(responseCode = "404", description = "질문 또는 유저 없음")
     })
     @PostMapping
-    public ResponseEntity<Void> createAnswer(//@AuthenticationPrincipal
-                                             User user,
+    public ResponseEntity<Void> createAnswer(@AuthenticationPrincipal User user,
                                              @Parameter(description = "질문 날짜", example = "2024-07-17") @PathVariable LocalDate date,
                                              @Valid @RequestBody AnswerRequest request) {
         Long answerId = answerService.createAnswer(user, date,request);
@@ -52,8 +52,7 @@ public class AnswerController {
             @ApiResponse(responseCode = "404", description = "답변 없음")
     })
     @GetMapping
-    public ResponseEntity<AnswerResponse> getAnswer(//@AuthenticationPrincipal
-                                                    User user,
+    public ResponseEntity<AnswerResponse> getAnswer(@AuthenticationPrincipal User user,
                                                     @Parameter(description = "질문 날짜", example = "2024-07-17") @PathVariable LocalDate date){
         return ResponseEntity.ok(answerService.getAnswer(user,date));
     }

--- a/src/main/java/efub/cpbr/crumble/auth/controller/AuthController.java
+++ b/src/main/java/efub/cpbr/crumble/auth/controller/AuthController.java
@@ -27,8 +27,8 @@ public class AuthController {
     }
 
     // 로그인 API
-//    @PostMapping("/login")
-//    public TokenInfo login(@Valid @RequestBody LoginRequestDto request) {
-//        return authService.login(request);
-//    }
+    @PostMapping("/login")
+    public TokenInfo login(@Valid @RequestBody LoginRequestDto request) {
+        return authService.login(request);
+    }
 }

--- a/src/main/java/efub/cpbr/crumble/auth/service/AuthService.java
+++ b/src/main/java/efub/cpbr/crumble/auth/service/AuthService.java
@@ -67,38 +67,38 @@ public class AuthService {
 
 
     // 로그인 로직
-//    public TokenInfo login(LoginRequestDto loginRequestDto) {
-//        log.info("로그인 시도: 사용자명 = {}", loginRequestDto.getUsername());
-//
-//        // 1. 인증 토큰 생성
-//        UsernamePasswordAuthenticationToken authenticationToken =
-//                new UsernamePasswordAuthenticationToken(loginRequestDto.getUsername(), loginRequestDto.getPassword());
-//
-//        try {
-//            // 2. AuthenticationManager를 통해 인증 수행
-//            // 이 시점에서 UserDetailsService.loadUserByUsername()과 PasswordEncoder.matches()가 내부적으로 호출됩니다.
-//            Authentication authentication = authenticationManager.authenticate(authenticationToken);
-//            log.info("인증 성공: 사용자명 = {}", authentication.getName());
-//
-//            // 3. 인증 정보로 JWT 토큰 생성
-//            TokenInfo tokenInfo = jwtTokenProvider.generateToken(authentication);
-//            log.info("JWT 토큰 생성 완료");
-//
-//            // 4. 리프레시 토큰 레디스에 저장 (선택 사항, Redis 설정이 올바른지 확인 필요)
-//            redisTemplate.opsForValue().set("RT:" + authentication.getName(),
-//                    tokenInfo.getRefreshToken(),
-//                    jwtTokenProvider.getRefreshTokenExpirationMillis(),
-//                    TimeUnit.MILLISECONDS);
-//            log.info("리프레시 토큰 Redis에 저장 완료");
-//
-//            return tokenInfo;
-//
-//        } catch (Exception e) {
-//            // BadCredentialsException, UsernameNotFoundException 등 AuthenticationManager.authenticate()에서
-//            // 발생할 수 있는 예외를 여기서 잡아서 로그를 남깁니다.
-//            // 이 예외는 GlobalExceptionHandler에서 처리될 것입니다.
-//            log.error("로그인 인증 실패: {}", e.getMessage());
-//            throw e; // 예외를 다시 던져 GlobalExceptionHandler가 잡도록 합니다.
-//        }
-//    }
+    public TokenInfo login(LoginRequestDto loginRequestDto) {
+        log.info("로그인 시도: 사용자명 = {}", loginRequestDto.getUsername());
+
+        // 1. 인증 토큰 생성
+        UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(loginRequestDto.getUsername(), loginRequestDto.getPassword());
+
+        try {
+            // 2. AuthenticationManager를 통해 인증 수행
+            // 이 시점에서 UserDetailsService.loadUserByUsername()과 PasswordEncoder.matches()가 내부적으로 호출됩니다.
+            Authentication authentication = authenticationManager.authenticate(authenticationToken);
+            log.info("인증 성공: 사용자명 = {}", authentication.getName());
+
+            // 3. 인증 정보로 JWT 토큰 생성
+            TokenInfo tokenInfo = jwtTokenProvider.generateToken(authentication);
+            log.info("JWT 토큰 생성 완료");
+
+            // 4. 리프레시 토큰 레디스에 저장 (선택 사항, Redis 설정이 올바른지 확인 필요)
+            redisTemplate.opsForValue().set("RT:" + authentication.getName(),
+                    tokenInfo.getRefreshToken(),
+                    jwtTokenProvider.getRefreshTokenExpirationMillis(),
+                    TimeUnit.MILLISECONDS);
+            log.info("리프레시 토큰 Redis에 저장 완료");
+
+            return tokenInfo;
+
+        } catch (Exception e) {
+            // BadCredentialsException, UsernameNotFoundException 등 AuthenticationManager.authenticate()에서
+            // 발생할 수 있는 예외를 여기서 잡아서 로그를 남깁니다.
+            // 이 예외는 GlobalExceptionHandler에서 처리될 것입니다.
+            log.error("로그인 인증 실패: {}", e.getMessage());
+            throw e; // 예외를 다시 던져 GlobalExceptionHandler가 잡도록 합니다.
+        }
+    }
 }

--- a/src/main/java/efub/cpbr/crumble/calendar/controller/CalendarController.java
+++ b/src/main/java/efub/cpbr/crumble/calendar/controller/CalendarController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,8 +37,7 @@ public class CalendarController {
             @ApiResponse(responseCode = "401", description = "인증 정보 없음")
     })
     @GetMapping("/calendar/answers")
-    public ResponseEntity<AnsweredDatesResponse> getAnsweredDates(//@AuthenticationPrincipal
-                                                                  User user,
+    public ResponseEntity<AnsweredDatesResponse> getAnsweredDates(@AuthenticationPrincipal User user,
                                                                   @Parameter(description = "조회 연도", example = "2025")
                                                                       @RequestParam int year,
                                                                   @Parameter(description = "조회 월", example = "3")
@@ -55,8 +55,7 @@ public class CalendarController {
             @ApiResponse(responseCode = "401", description = "인증 정보 없음")
     })
     @GetMapping("/answers/me")
-    public ResponseEntity<List<AnswerDto>> getMonthlyAnswers(//@AuthenticationPrincipal
-                                                             User user,
+    public ResponseEntity<List<AnswerDto>> getMonthlyAnswers(@AuthenticationPrincipal User user,
                                                              @Parameter(description = "조회 연도", example = "2025")
                                                                  @RequestParam int year,
                                                              @Parameter(description = "조회 월", example = "3")
@@ -76,8 +75,7 @@ public class CalendarController {
             @ApiResponse(responseCode = "401", description = "인증 정보 없음")
     })
     @GetMapping("/answers/streak")
-    public ResponseEntity<Integer> getStreak(//@AuthenticationPrincipal
-                                             User user) {
+    public ResponseEntity<Integer> getStreak(@AuthenticationPrincipal User user) {
         int streak = calendarService.getStreak(user);
         return ResponseEntity.ok(streak);
     }
@@ -92,8 +90,7 @@ public class CalendarController {
             @ApiResponse(responseCode = "401", description = "인증 정보 없음")
     })
     @GetMapping("/cookies")
-    public ResponseEntity<Integer> getMonthlyCookieCount(//@AuthenticationPrincipal
-                                                         User user,
+    public ResponseEntity<Integer> getMonthlyCookieCount(@AuthenticationPrincipal User user,
                                                          @Parameter(description = "조회 연도", example = "2025")
                                                              @RequestParam int year,
                                                          @Parameter(description = "조회 월", example = "3")

--- a/src/main/java/efub/cpbr/crumble/global/config/RedisConfig.java
+++ b/src/main/java/efub/cpbr/crumble/global/config/RedisConfig.java
@@ -1,17 +1,32 @@
 package efub.cpbr.crumble.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
+    @Value("${REDIS_HOST}")
+    private String redisHost;
+
+    @Value("${REDIS_PORT}")
+    private int redisPort;
+
+    @Value("${REDIS_DATABASE}")
+    private int redisDatabase;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(); // 또는 환경 설정 추가 가능
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setHostName(redisHost);
+        config.setPort(redisPort);
+        config.setDatabase(redisDatabase);
+        return new LettuceConnectionFactory(config);
     }
 
     @Bean

--- a/src/main/java/efub/cpbr/crumble/global/config/WebSecurityConfig.java
+++ b/src/main/java/efub/cpbr/crumble/global/config/WebSecurityConfig.java
@@ -22,7 +22,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class WebSecurityConfig {
 
     //private final UserDetailsServiceImpl userDetailsService;
-    //private final JwtTokenProvider jwtTokenProvider; // JWT 필터에 필요 (지금은 주석)
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -52,9 +52,7 @@ public class WebSecurityConfig {
                         .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요
                 )
 
-        // 로그인 테스트가 성공하면 그때 활성화하여 테스트
-        // .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
-        ;
+        .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 }

--- a/src/main/java/efub/cpbr/crumble/item/controller/FortuneController.java
+++ b/src/main/java/efub/cpbr/crumble/item/controller/FortuneController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -35,8 +36,7 @@ public class FortuneController {
             @ApiResponse(responseCode = "404", description = "과거의 답변 존재하지 않음")
     })
     @GetMapping
-    public ResponseEntity<FortuneAnswerResponse> getFortune(//@AuthenticationPrincipal
-                                                            User user) {
+    public ResponseEntity<FortuneAnswerResponse> getFortune(@AuthenticationPrincipal User user) {
         return ResponseEntity.ok(fortuneService.getFortune(user));
     }
 
@@ -50,8 +50,7 @@ public class FortuneController {
             @ApiResponse(responseCode = "401", description = "인증 정보 없음")
     })
     @GetMapping("/used")
-    public ResponseEntity<FortuneUseCheckResponse> checkTodayUse(//@AuthenticationPrincipal
-                                                                 User user) {
+    public ResponseEntity<FortuneUseCheckResponse> checkTodayUse(@AuthenticationPrincipal User user) {
         return ResponseEntity.ok(fortuneService.checkTodayUse(user));
     }
 

--- a/src/main/java/efub/cpbr/crumble/item/controller/UserItemController.java
+++ b/src/main/java/efub/cpbr/crumble/item/controller/UserItemController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -35,8 +36,7 @@ public class UserItemController {
     })
     @PostMapping("/use")
     public ResponseEntity<Void> useItem(
-            //@AuthenticationPrincipal
-            User user,
+            @AuthenticationPrincipal User user,
             @Parameter(description = "아이템 타입", example = "SHIELD")
                 @RequestParam ItemType type
     ) {
@@ -54,9 +54,7 @@ public class UserItemController {
             @ApiResponse(responseCode = "401", description = "인증 정보 없음"),
     })
     @GetMapping("/count")
-    public ResponseEntity<List<ItemCountResponse>> getMyItems(
-            //@AuthenticationPrincipal
-            User user
+    public ResponseEntity<List<ItemCountResponse>> getMyItems(@AuthenticationPrincipal User user
     ) {
         List<ItemCountResponse> items = itemService.getUserItemCounts(user);
         return ResponseEntity.ok(items);

--- a/src/main/java/efub/cpbr/crumble/jwt/JwtTokenProvider.java
+++ b/src/main/java/efub/cpbr/crumble/jwt/JwtTokenProvider.java
@@ -1,5 +1,9 @@
 package efub.cpbr.crumble.jwt;
 
+import efub.cpbr.crumble.global.exception.CustomException;
+import efub.cpbr.crumble.global.exception.ErrorCode;
+import efub.cpbr.crumble.user.entity.User;
+import efub.cpbr.crumble.user.repository.UserRepository;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
@@ -9,8 +13,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -24,6 +26,7 @@ import java.util.stream.Collectors;
 public class JwtTokenProvider {
 
     private final SecretKey key; // JWT 서명에 사용될 비밀 키
+    private final UserRepository userRepository;
 
     // Access Token 만료 시간 (밀리초)
     @Value("${jwt.access-token-expiration-millis}")
@@ -33,7 +36,8 @@ public class JwtTokenProvider {
     @Value("${jwt.refresh-token-expiration-millis}")
     private long refreshTokenExpirationMillis;
 
-    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey) {
+    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey, UserRepository userRepository) {
+        this.userRepository = userRepository;
         byte[] keyBytes = Decoders.BASE64.decode(secretKey); // Base64로 인코딩된 secretKey 디코딩
         this.key = Keys.hmacShaKeyFor(keyBytes); // HMAC SHA 키 생성
     }
@@ -87,10 +91,12 @@ public class JwtTokenProvider {
 
 
         // 스프링 시큐리티 User 생성 시 비밀번호는 "" (빈 문자열)로 설정
-        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        //UserDetails principal = new User(claims.getSubject(), "", authorities);
+        User user = userRepository.findByUsername(claims.getSubject())
+                .orElseThrow(()->new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // Authentication return
-        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+        return new UsernamePasswordAuthenticationToken(user, "", authorities);
     }
 
     // 토큰 유효성 검증

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,16 +17,16 @@ spring:
       hibernate:
         format_sql: true
 
-  jwt:
-    secret: ${JWT_KEY}
-    access-token-expiration-millis: 3600000 # 1시간
-    refresh-token-expiration-millis: 604800000 # 7일
-
   data:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
       database: ${REDIS_DATABASE}
+
+jwt:
+  secret: ${JWT_KEY}
+  access-token-expiration-millis: 3600000 # 1시간
+  refresh-token-expiration-millis: 604800000 # 7일
 
 cors:
   allow-origins:
@@ -35,9 +35,3 @@ cors:
 
 openai:
   api-key: ${API_KEY}
-
-logging:
-  level:
-    root: INFO
-    org.springframework: DEBUG
-    efub.cpbr.crumble: DEBUG


### PR DESCRIPTION
## 🔧 작업 사항(Summary)<!--- 진행한 작업에 대해 설명해주세요. -->
- [x] application.yml의 jwt 설정 위치와 중복 수정
- [x] 로그인 API 주요 에러 해결
- [x] Redis 환경변수(호스트, 포트, DB) 기반 RedisConfig 개선
- [x] 컨트롤러 인증 주입(@AuthenticationPrincipal) 기능 정상화 및 주석 해제

## ✨ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정


## 📸 스크린샷 or Test 결과 (선택)
#### answer @ Authentication User user 테스트
<img width="1017" height="369" alt="image" src="https://github.com/user-attachments/assets/206fe730-f28c-4edc-a16a-e856801ca998" />

### login api test
<img width="876" height="286" alt="image" src="https://github.com/user-attachments/assets/0c88819c-61b3-473a-9ee9-6acc768b44b4" />

## 기타
- Controller에서 User 객체 주입 받도록 수정하시면 됩니다. 
- reissue, refreshtoken logout ..등등 추가적으로 구현하면 될 것 같아요 ~~

## 📌 Issue Number<!--- ex) #이슈이름, #이슈번호 -->

- #19 
