### PR TITLE
[FEAT] 영어 문법 검사 기능 및 관련 API 구현

### DIFF
--- a/src/main/java/efub/cpbr/crumble/answer/controller/AnswerController.java
+++ b/src/main/java/efub/cpbr/crumble/answer/controller/AnswerController.java
@@ -3,6 +3,7 @@ package efub.cpbr.crumble.answer.controller;
 import efub.cpbr.crumble.answer.dto.req.AnswerRequest;
 import efub.cpbr.crumble.answer.dto.res.AnswerResponse;
 import efub.cpbr.crumble.answer.service.AnswerService;
+import efub.cpbr.crumble.auth.service.CustomUserDetails;
 import efub.cpbr.crumble.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -36,9 +37,10 @@ public class AnswerController {
             @ApiResponse(responseCode = "404", description = "질문 또는 유저 없음")
     })
     @PostMapping
-    public ResponseEntity<Void> createAnswer(@AuthenticationPrincipal User user,
+    public ResponseEntity<Void> createAnswer(@AuthenticationPrincipal CustomUserDetails userDetails,
                                              @Parameter(description = "질문 날짜", example = "2024-07-17") @PathVariable LocalDate date,
                                              @Valid @RequestBody AnswerRequest request) {
+        User user = userDetails.getUser();
         Long answerId = answerService.createAnswer(user, date,request);
         return ResponseEntity.created(URI.create("/question/"+date+"/answer/"+answerId)).build();
     }
@@ -52,8 +54,9 @@ public class AnswerController {
             @ApiResponse(responseCode = "404", description = "답변 없음")
     })
     @GetMapping
-    public ResponseEntity<AnswerResponse> getAnswer(@AuthenticationPrincipal User user,
+    public ResponseEntity<AnswerResponse> getAnswer(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                     @Parameter(description = "질문 날짜", example = "2024-07-17") @PathVariable LocalDate date){
+        User user = userDetails.getUser();
         return ResponseEntity.ok(answerService.getAnswer(user,date));
     }
 }

--- a/src/main/java/efub/cpbr/crumble/auth/service/AuthService.java
+++ b/src/main/java/efub/cpbr/crumble/auth/service/AuthService.java
@@ -57,8 +57,6 @@ public class AuthService {
                 .role(RoleType.USER) // 기본 역할 USER로 설정
                 .point(0) // 초기 포인트 0으로 설정
                 .isActive(true) // 계정 활성화 상태로 설정
-                .createdAt(LocalDateTime.now()) // 현재 시간으로 생성 시간 설정
-                .updatedAt(LocalDateTime.now()) // 현재 시간으로 업데이트 시간 설정
                 .build();
 
         // 사용자 정보 저장

--- a/src/main/java/efub/cpbr/crumble/auth/service/CustomUserDetails.java
+++ b/src/main/java/efub/cpbr/crumble/auth/service/CustomUserDetails.java
@@ -18,6 +18,7 @@ public class CustomUserDetails implements UserDetails {
     public User getUser(){
         return user;
     }
+    public Long getUserId(){return user.getUserId();}
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/efub/cpbr/crumble/auth/service/CustomUserDetails.java
+++ b/src/main/java/efub/cpbr/crumble/auth/service/CustomUserDetails.java
@@ -52,7 +52,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public boolean isEnabled() {
-        return user.isEnabled(); // User 엔티티의 isActive 필드 사용
+        return user.isActive();
     }
 
     @Override

--- a/src/main/java/efub/cpbr/crumble/auth/service/CustomUserDetails.java
+++ b/src/main/java/efub/cpbr/crumble/auth/service/CustomUserDetails.java
@@ -1,58 +1,62 @@
-//package efub.cpbr.crumble.auth.service; // 또는 적절한 패키지 경로
-//
-//import efub.cpbr.crumble.user.entity.User; // User 엔티티 임포트
-//import org.springframework.security.core.GrantedAuthority;
-//import org.springframework.security.core.authority.SimpleGrantedAuthority;
-//import org.springframework.security.core.userdetails.UserDetails;
-//
-//import java.util.Collection;
-//import java.util.Collections;
-//
-//public class CustomUserDetails implements UserDetails {
-//    private final User user;
-//
-//    public CustomUserDetails(User user) {
-//        this.user = user;
-//    }
-//
-//    @Override
-//    public Collection<? extends GrantedAuthority> getAuthorities() {
-//        // User 엔티티의 role 필드를 사용하여 권한을 생성
-//        return Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
-//    }
-//
-//    @Override
-//    public String getPassword() {
-//        return user.getPassword();
-//    }
-//
-//    @Override
-//    public String getUsername() {
-//        return user.getUsername();
-//    }
-//
-//    @Override
-//    public boolean isAccountNonExpired() {
-//        return true; // 계정 만료 여부 (항상 true)
-//    }
-//
-//    @Override
-//    public boolean isAccountNonLocked() {
-//        return true; // 계정 잠금 여부 (항상 true)
-//    }
-//
-//    @Override
-//    public boolean isCredentialsNonExpired() {
-//        return true; // 자격 증명(비밀번호) 만료 여부 (항상 true)
-//    }
-//
-//    @Override
-//    public boolean isEnabled() {
-//        return user.isEnabled(); // User 엔티티의 isActive 필드 사용
-//    }
-//
-//    @Override
-//    public String toString() {
-//        return "CustomUserDetails(username=" + user.getUsername() + ", role=" + user.getRole() + ")";
-//    }
-//}
+package efub.cpbr.crumble.auth.service; // 또는 적절한 패키지 경로
+
+import efub.cpbr.crumble.user.entity.User; // User 엔티티 임포트
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    public User getUser(){
+        return user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // User 엔티티의 role 필드를 사용하여 권한을 생성
+        return Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true; // 계정 만료 여부 (항상 true)
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true; // 계정 잠금 여부 (항상 true)
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true; // 자격 증명(비밀번호) 만료 여부 (항상 true)
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return user.isEnabled(); // User 엔티티의 isActive 필드 사용
+    }
+
+    @Override
+    public String toString() {
+        return "CustomUserDetails(username=" + user.getUsername() + ", role=" + user.getRole() + ")";
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/auth/service/UserDetailsServiceImpl.java
+++ b/src/main/java/efub/cpbr/crumble/auth/service/UserDetailsServiceImpl.java
@@ -1,22 +1,23 @@
-//package efub.cpbr.crumble.auth.service;
-//
-//import efub.cpbr.crumble.user.repository.UserRepository;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.security.core.userdetails.UserDetails;
-//import org.springframework.security.core.userdetails.UserDetailsService;
-//import org.springframework.security.core.userdetails.UsernameNotFoundException;
-//import org.springframework.stereotype.Service;
-//
-//@Service
-//@RequiredArgsConstructor
-//public class UserDetailsServiceImpl implements UserDetailsService {
-//    private final UserRepository userRepository;
-//
-//    @Override
-//    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-//        // 사용자 이름으로 DB에서 사용자 엔티티를 찾고, CustomUserDetails로 변환하여 반환
-//        return userRepository.findByUsername(username)
-//                .map(CustomUserDetails::new) // User 엔티티를 CustomUserDetails로 변환
-//                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + username));
-//    }
-//}
+package efub.cpbr.crumble.auth.service;
+
+import efub.cpbr.crumble.global.exception.CustomException;
+import efub.cpbr.crumble.global.exception.ErrorCode;
+import efub.cpbr.crumble.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) {
+        // 사용자 이름으로 DB에서 사용자 엔티티를 찾고, CustomUserDetails로 변환하여 반환
+        return userRepository.findByUsername(username)
+                .map(CustomUserDetails::new) // User 엔티티를 CustomUserDetails로 변환
+                .orElseThrow(()->new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/global/config/RedisConfig.java
+++ b/src/main/java/efub/cpbr/crumble/global/config/RedisConfig.java
@@ -7,6 +7,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -37,6 +38,17 @@ public class RedisConfig {
         // key, value 직렬화 설정
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new StringRedisSerializer());
+
+        return template;
+    }
+
+    @Bean
+    public RedisTemplate<String, Boolean> booleanRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Boolean> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericToStringSerializer<>(Boolean.class));
 
         return template;
     }

--- a/src/main/java/efub/cpbr/crumble/global/exception/ErrorCode.java
+++ b/src/main/java/efub/cpbr/crumble/global/exception/ErrorCode.java
@@ -17,6 +17,9 @@ public enum ErrorCode {
     HINT_NOT_FOUND(404, "해당 날짜의 질문에 대한 힌트가 존재하지 않습니다."),
     // Answer 관련 에러
     ANSWER_NOT_FOUND(404, "해당 답변이 존재하지 않습니다."),
+    // Grammar 관련 에러
+    GRAMMAR_TEXT_EMPTY(400, "검사할 텍스트가 비어있습니다."),
+    GRAMMAR_PARSE_FAILED(500, "문법 검사 결과 파싱에 실패했습니다."),
 
     // community
     ALREADY_LIKED(400, "이미 좋아요를 누른 게시글입니다."),

--- a/src/main/java/efub/cpbr/crumble/grammar/controller/GrammarController.java
+++ b/src/main/java/efub/cpbr/crumble/grammar/controller/GrammarController.java
@@ -1,0 +1,34 @@
+package efub.cpbr.crumble.grammar.controller;
+
+import efub.cpbr.crumble.auth.service.CustomUserDetails;
+import efub.cpbr.crumble.global.exception.CustomException;
+import efub.cpbr.crumble.global.exception.ErrorCode;
+import efub.cpbr.crumble.grammar.dto.req.GrammarRequest;
+import efub.cpbr.crumble.grammar.dto.res.GrammarResponse;
+import efub.cpbr.crumble.grammar.service.GrammarCheckService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/grammar")
+@RequiredArgsConstructor
+public class GrammarController {
+
+    private final GrammarCheckService grammarCheckService;
+
+    @PostMapping("/check")
+    public ResponseEntity<GrammarResponse> checkGrammar(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                        @RequestBody GrammarRequest request){
+        if(request.text() == null || request.text().isBlank()){
+            throw new CustomException(ErrorCode.GRAMMAR_TEXT_EMPTY);
+        }
+        GrammarResponse response = grammarCheckService.checkGrammar(userDetails.getUserId(),request.text());
+        return ResponseEntity.ok(response);
+
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/grammar/controller/GrammarController.java
+++ b/src/main/java/efub/cpbr/crumble/grammar/controller/GrammarController.java
@@ -6,6 +6,10 @@ import efub.cpbr.crumble.global.exception.ErrorCode;
 import efub.cpbr.crumble.grammar.dto.req.GrammarRequest;
 import efub.cpbr.crumble.grammar.dto.res.GrammarResponse;
 import efub.cpbr.crumble.grammar.service.GrammarCheckService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -14,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Grammar", description = "영어 문법 검사 API")
 @RestController
 @RequestMapping("/api/grammar")
 @RequiredArgsConstructor
@@ -21,6 +26,15 @@ public class GrammarController {
 
     private final GrammarCheckService grammarCheckService;
 
+    @Operation(
+            summary = "영어 문법 검사 요청",
+            description = "사용자가 입력한 영어 문장을 검사하여 문법 오류 정보를 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "문법 검사 성공"),
+            @ApiResponse(responseCode = "400", description = "검사할 텍스트가 비어있음"),
+            @ApiResponse(responseCode = "500", description = "문법 검사 처리 중 파싱 실패 에러")
+    })
     @PostMapping("/check")
     public ResponseEntity<GrammarResponse> checkGrammar(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                         @RequestBody GrammarRequest request){

--- a/src/main/java/efub/cpbr/crumble/grammar/dto/req/GrammarRequest.java
+++ b/src/main/java/efub/cpbr/crumble/grammar/dto/req/GrammarRequest.java
@@ -1,0 +1,5 @@
+package efub.cpbr.crumble.grammar.dto.req;
+
+public record GrammarRequest(
+        String text
+) {}

--- a/src/main/java/efub/cpbr/crumble/grammar/dto/res/GrammarError.java
+++ b/src/main/java/efub/cpbr/crumble/grammar/dto/res/GrammarError.java
@@ -1,0 +1,10 @@
+package efub.cpbr.crumble.grammar.dto.res;
+
+import java.util.List;
+
+public record GrammarError(
+        String message,
+        int offset,
+        int length,
+        List<String> replacements
+) {}

--- a/src/main/java/efub/cpbr/crumble/grammar/dto/res/GrammarResponse.java
+++ b/src/main/java/efub/cpbr/crumble/grammar/dto/res/GrammarResponse.java
@@ -1,0 +1,9 @@
+package efub.cpbr.crumble.grammar.dto.res;
+
+import java.util.List;
+
+public record GrammarResponse(
+        String originalText,
+        List<GrammarError> errors
+) {
+}

--- a/src/main/java/efub/cpbr/crumble/grammar/service/GrammarCheckRedisService.java
+++ b/src/main/java/efub/cpbr/crumble/grammar/service/GrammarCheckRedisService.java
@@ -1,0 +1,32 @@
+package efub.cpbr.crumble.grammar.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class GrammarCheckRedisService {
+    private final RedisTemplate<String, Boolean> redisTemplate;
+
+    public void saveDailyGrammarCheck(Long userId){
+        String redisKey = "daily_grammar_check_" + userId;
+        redisTemplate.opsForValue().set(redisKey, true, Duration.ofSeconds(getSecondsUntilMidnight()));
+    }
+
+    // 자정까지 남은 시간 계산
+    private long getSecondsUntilMidnight() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime midnight = now.toLocalDate().plusDays(1).atStartOfDay();
+        return Duration.between(now, midnight).getSeconds();
+    }
+
+    public boolean isCheckedToday(Long userId) {
+        String redisKey = "daily_grammar_check_" + userId;
+        Boolean checked = redisTemplate.opsForValue().get(redisKey);
+        return checked != null && checked;
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/grammar/service/GrammarCheckService.java
+++ b/src/main/java/efub/cpbr/crumble/grammar/service/GrammarCheckService.java
@@ -1,0 +1,76 @@
+package efub.cpbr.crumble.grammar.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import efub.cpbr.crumble.global.exception.CustomException;
+import efub.cpbr.crumble.global.exception.ErrorCode;
+import efub.cpbr.crumble.grammar.dto.res.GrammarError;
+import efub.cpbr.crumble.grammar.dto.res.GrammarResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+public class GrammarCheckService {
+    private final GrammarCheckRedisService grammarCheckRedisService;
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final String LANGUAGETOOL_API_URL="https://api.languagetool.org/v2/check";
+
+    public GrammarResponse checkGrammar(Long userId,String text){
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        map.add("text", text);
+        map.add("language", "en-US");
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(map, headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                LANGUAGETOOL_API_URL,
+                HttpMethod.POST,
+                request,
+                String.class);
+
+        String responseBody = response.getBody();
+
+        try{
+            List<GrammarError> errors = mapToResponse(responseBody);
+            // 문법 검사 여부 저장
+            grammarCheckRedisService.saveDailyGrammarCheck(userId);
+            return new GrammarResponse(text, errors);
+        }catch (Exception e){
+            throw new CustomException(ErrorCode.GRAMMAR_PARSE_FAILED);
+        }
+    }
+
+    private List<GrammarError> mapToResponse(String responseBody) throws JsonProcessingException {
+        System.out.println(responseBody);
+        JsonNode rootNode = objectMapper.readTree(responseBody);
+
+        List<GrammarError> errors = new ArrayList<>();
+        JsonNode matches = rootNode.path("matches");
+        for(JsonNode match : matches){
+            String message = match.path("message").asText();
+            int offset = match.path("offset").asInt();
+            int length = match.path("length").asInt();
+
+            List<String> replacements = new ArrayList<>();
+            for(JsonNode rep : match.path("replacements")) {
+                replacements.add(rep.path("value").asText());
+            }
+            errors.add(new GrammarError(message, offset, length, replacements));
+        }
+        return errors;
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/jwt/JwtTokenProvider.java
+++ b/src/main/java/efub/cpbr/crumble/jwt/JwtTokenProvider.java
@@ -1,9 +1,5 @@
 package efub.cpbr.crumble.jwt;
 
-import efub.cpbr.crumble.global.exception.CustomException;
-import efub.cpbr.crumble.global.exception.ErrorCode;
-import efub.cpbr.crumble.user.entity.User;
-import efub.cpbr.crumble.user.repository.UserRepository;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
@@ -13,6 +9,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -26,7 +24,7 @@ import java.util.stream.Collectors;
 public class JwtTokenProvider {
 
     private final SecretKey key; // JWT 서명에 사용될 비밀 키
-    private final UserRepository userRepository;
+    private final UserDetailsService userDetailsService;
 
     // Access Token 만료 시간 (밀리초)
     @Value("${jwt.access-token-expiration-millis}")
@@ -36,8 +34,8 @@ public class JwtTokenProvider {
     @Value("${jwt.refresh-token-expiration-millis}")
     private long refreshTokenExpirationMillis;
 
-    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey, UserRepository userRepository) {
-        this.userRepository = userRepository;
+    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey, UserDetailsService userDetailsService) {
+        this.userDetailsService = userDetailsService;
         byte[] keyBytes = Decoders.BASE64.decode(secretKey); // Base64로 인코딩된 secretKey 디코딩
         this.key = Keys.hmacShaKeyFor(keyBytes); // HMAC SHA 키 생성
     }
@@ -91,12 +89,10 @@ public class JwtTokenProvider {
 
 
         // 스프링 시큐리티 User 생성 시 비밀번호는 "" (빈 문자열)로 설정
-        //UserDetails principal = new User(claims.getSubject(), "", authorities);
-        User user = userRepository.findByUsername(claims.getSubject())
-                .orElseThrow(()->new CustomException(ErrorCode.USER_NOT_FOUND));
+        UserDetails principal = userDetailsService.loadUserByUsername(claims.getSubject());
 
         // Authentication return
-        return new UsernamePasswordAuthenticationToken(user, "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
     }
 
     // 토큰 유효성 검증

--- a/src/main/java/efub/cpbr/crumble/question/controller/QuestionController.java
+++ b/src/main/java/efub/cpbr/crumble/question/controller/QuestionController.java
@@ -1,5 +1,7 @@
 package efub.cpbr.crumble.question.controller;
 
+import efub.cpbr.crumble.auth.service.CustomUserDetails;
+import efub.cpbr.crumble.question.dto.res.TodayQuestionResponse;
 import efub.cpbr.crumble.question.dto.res.QuestionResponse;
 import efub.cpbr.crumble.question.service.QuestionService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,8 +11,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
@@ -18,6 +22,7 @@ import java.time.LocalDate;
 @Tag(name = "Question", description = "질문 관련 API")
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/questions")
 public class QuestionController {
     private final QuestionService questionService;
 
@@ -29,9 +34,15 @@ public class QuestionController {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "404", description = "질문 없음")
     })
-    @GetMapping("/questions/{date}")
+    @GetMapping("/{date}")
     public ResponseEntity<QuestionResponse> getQuestion(
             @Parameter(description = "조회할 날짜 (yyyy-MM-dd)", example = "2025-07-08") @PathVariable LocalDate date) {
         return ResponseEntity.ok(questionService.getQuestion(date));
+    }
+
+    @GetMapping("/today")
+    public ResponseEntity<TodayQuestionResponse> getTodayQuestion(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(questionService.getTodayQuestion(userDetails.getUserId()));
     }
 }

--- a/src/main/java/efub/cpbr/crumble/question/controller/QuestionController.java
+++ b/src/main/java/efub/cpbr/crumble/question/controller/QuestionController.java
@@ -40,6 +40,14 @@ public class QuestionController {
         return ResponseEntity.ok(questionService.getQuestion(date));
     }
 
+    @Operation(
+            summary = "오늘의 질문 조회",
+            description = "사용자 ID에 기반해 오늘 날짜에 해당하는 질문을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "오늘 질문 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "오늘 질문이 존재하지 않음")
+    })
     @GetMapping("/today")
     public ResponseEntity<TodayQuestionResponse> getTodayQuestion(
             @AuthenticationPrincipal CustomUserDetails userDetails) {

--- a/src/main/java/efub/cpbr/crumble/question/dto/res/TodayQuestionResponse.java
+++ b/src/main/java/efub/cpbr/crumble/question/dto/res/TodayQuestionResponse.java
@@ -1,0 +1,17 @@
+package efub.cpbr.crumble.question.dto.res;
+
+import efub.cpbr.crumble.question.entity.Question;
+
+public record TodayQuestionResponse(
+        Long questionId,
+        String content,
+        boolean grammarChecked
+) {
+    public static TodayQuestionResponse from(Question question, boolean grammarChecked) {
+        return new TodayQuestionResponse(
+                question.getId(),
+                question.getContent(),
+                grammarChecked
+        );
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/question/service/QuestionService.java
+++ b/src/main/java/efub/cpbr/crumble/question/service/QuestionService.java
@@ -2,7 +2,9 @@ package efub.cpbr.crumble.question.service;
 
 import efub.cpbr.crumble.global.exception.CustomException;
 import efub.cpbr.crumble.global.exception.ErrorCode;
+import efub.cpbr.crumble.grammar.service.GrammarCheckRedisService;
 import efub.cpbr.crumble.question.dto.res.QuestionResponse;
+import efub.cpbr.crumble.question.dto.res.TodayQuestionResponse;
 import efub.cpbr.crumble.question.entity.Question;
 import efub.cpbr.crumble.question.entity.QuestionCategory;
 import efub.cpbr.crumble.question.repository.QuestionRepository;
@@ -16,11 +18,19 @@ import java.time.LocalDate;
 @RequiredArgsConstructor
 public class QuestionService {
     private final QuestionRepository questionRepository;
+    private final GrammarCheckRedisService grammarCheckRedisService;
     //private final EmbeddingStore<Document> vectorStore;
 
     @Transactional(readOnly = true)
     public QuestionResponse getQuestion(LocalDate date) {
         return QuestionResponse.from(findQuestionByDateOrThrow(date));
+    }
+
+    @Transactional(readOnly = true)
+    public TodayQuestionResponse getTodayQuestion(Long userId) {
+        Question question = findQuestionByDateOrThrow(LocalDate.now());
+        boolean grammarChecked = grammarCheckRedisService.isCheckedToday(userId);
+        return TodayQuestionResponse.from(question, grammarChecked);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/efub/cpbr/crumble/user/entity/User.java
+++ b/src/main/java/efub/cpbr/crumble/user/entity/User.java
@@ -1,6 +1,7 @@
 package efub.cpbr.crumble.user.entity;
 
 import efub.cpbr.crumble.community.comment.domain.Comment;
+import efub.cpbr.crumble.global.domain.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;
@@ -10,20 +11,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails; // import 추가
 
 
 @Entity
 @Getter
 @Table(name = "users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User {
+public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name="user_id")
@@ -49,22 +44,9 @@ public class User {
     @Column(nullable = false)
     private boolean isActive = true;
 
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private LocalDateTime updatedAt;
-
-    @PrePersist
-    protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = this.createdAt;
-    }
-
-    @PreUpdate
-    protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
-    }
+    private RoleType role;
 
     @Builder
     public User(Long userId, String username, String password, String email, String nickname,
@@ -76,8 +58,6 @@ public class User {
         this.nickname = nickname;
         this.point = (point == 0) ? 0 : point; // 기본값 처리
         this.isActive = isActive;
-        this.createdAt = (createdAt == null) ? LocalDateTime.now() : createdAt; // 기본값 처리
-        this.updatedAt = (updatedAt == null) ? LocalDateTime.now() : updatedAt; // 기본값 처리
         this.role = (role == null) ? RoleType.USER : role; // 기본 역할 처리
     }
 
@@ -92,19 +72,4 @@ public class User {
         this.point += point;
     }
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private RoleType role;
-
-    public String getPassword() {
-        return password; // User 엔티티의 password 필드 반환
-    }
-
-    public String getUsername() {
-        return username; // User 엔티티의 username 필드 반환 (로그인 ID)
-    }
-
-    public boolean isEnabled() {
-        return isActive; // User 엔티티의 isActive 필드 반환 (계정 활성화 여부)
-    }
 }

--- a/src/main/java/efub/cpbr/crumble/user/service/UserService.java
+++ b/src/main/java/efub/cpbr/crumble/user/service/UserService.java
@@ -12,22 +12,9 @@ import java.util.Collections;
 
 @Service
 @RequiredArgsConstructor
-public class UserService implements UserDetailsService {
+public class UserService {
 
     private final UserRepository userRepository;
+    //사용자 정보 관리(조회/수정/등록 등)만 UserService에
 
-    @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return userRepository.findByUsername(username)
-                .map(this::createUserDetails)
-                .orElseThrow(() -> new UsernameNotFoundException(username + " -> 데이터베이스에서 찾을 수 없습니다."));
-    }
-
-    private UserDetails createUserDetails(User user) {
-        return new org.springframework.security.core.userdetails.User(
-                user.getUsername(),
-                user.getPassword(),
-                Collections.singleton(new org.springframework.security.core.authority.SimpleGrantedAuthority("ROLE_" + user.getRole().name()))
-        );
-    }
 }


### PR DESCRIPTION
## 🔧 작업 사항(Summary)<!--- 진행한 작업에 대해 설명해주세요. -->
- [x] 문법 검사 api로 LanguageTool API 연동 기능 추가
- [x] 문법 검사 여부 Redis 저장 및 Config 빈 추가
- [x] QuestionController에 오늘의 질문과 문법 검사 여부 함께 반환하 API 추가

## ✨ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가


## 📸 스크린샷 or Test 결과 (선택)
#### 문법 검사 결과 응답
<img width="783" height="494" alt="스크린샷 2025-08-01 204517" src="https://github.com/user-attachments/assets/e5457177-7931-4766-9e3d-c29e7b1f68b7" />

#### 문법 검사 여부 테스트
<img width="1320" height="259" alt="스크린샷 2025-08-01 213813" src="https://github.com/user-attachments/assets/a4c3ec5d-ec99-4f97-8696-102f90fba7b5" />


## 기타 
- 우선 무료 api를 제공하는 LanguageTool api 를 사용했습니다.
- 문법 검사를 하루에 한번으로 제한하기 위해 redis에 TTL을 설정해서 저장했습니다.

## 📌 Issue Number<!--- ex) #이슈이름, #이슈번호 -->

- closes #34 
