### PR TITLE
[FEAT] 커뮤니티 유저 조회 api

### DIFF
--- a/src/main/java/efub/cpbr/crumble/answer/repository/AnswerRepository.java
+++ b/src/main/java/efub/cpbr/crumble/answer/repository/AnswerRepository.java
@@ -1,12 +1,16 @@
 package efub.cpbr.crumble.answer.repository;
 
 import efub.cpbr.crumble.answer.entity.Answer;
+import efub.cpbr.crumble.community.post.domain.Post;
 import efub.cpbr.crumble.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
     Optional<Answer> findByUserAndQuestion_Date(User user, LocalDate date);
+
+    List<Answer> findTop5ByUserAndIsPublicTrueOrderByCreatedAtDesc(User user);
 }

--- a/src/main/java/efub/cpbr/crumble/answer/service/AnswerService.java
+++ b/src/main/java/efub/cpbr/crumble/answer/service/AnswerService.java
@@ -26,6 +26,8 @@ public class AnswerService {
         Question question = questionService.findQuestionByDateOrThrow(date);
 
         Answer answer = request.toEntity(question,user);
+        answer.getUser().getUserStat().increaseTotalAnswers();
+
         return answerRepository.save(answer).getId();
     }
 

--- a/src/main/java/efub/cpbr/crumble/auth/service/AuthService.java
+++ b/src/main/java/efub/cpbr/crumble/auth/service/AuthService.java
@@ -8,7 +8,9 @@ import efub.cpbr.crumble.jwt.JwtTokenProvider;
 import efub.cpbr.crumble.jwt.TokenInfo;
 import efub.cpbr.crumble.user.entity.RoleType;
 import efub.cpbr.crumble.user.entity.User;
+import efub.cpbr.crumble.user.entity.UserStat;
 import efub.cpbr.crumble.user.repository.UserRepository;
+import efub.cpbr.crumble.user.repository.UserStatRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -31,6 +33,7 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisTemplate<String, String> redisTemplate;
     private final PasswordEncoder passwordEncoder;
+    private final UserStatRepository userStatRepository;
 
     // 회원가입 로직
     public User signup(SignUpRequestDto signUpRequestDto) {
@@ -59,8 +62,22 @@ public class AuthService {
                 .isActive(true) // 계정 활성화 상태로 설정
                 .build();
 
+        User savedUser = userRepository.save(newUser);
+
+        // UserStat 생성 및 저장 (초기값 0으로 세팅)
+        UserStat userStat = UserStat.builder()
+                .user(savedUser)
+                .totalAnswers(0)
+                .currentStreak(0)
+                .longestStreak(0)
+                .totalLikesReceived(0)
+                .totalCommentsReceived(0)
+                .build();
+
+        userStatRepository.save(userStat);
+
         // 사용자 정보 저장
-        return userRepository.save(newUser);
+        return savedUser;
     }
 
 

--- a/src/main/java/efub/cpbr/crumble/community/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/efub/cpbr/crumble/community/comment/dto/response/CommentResponseDto.java
@@ -12,6 +12,7 @@ public class CommentResponseDto {
     private Long commentId;
     private String commentator;
     private Long commentatorId;
+    private int profileImageId;
     private String content;
     private LocalDateTime createdAt;
 
@@ -20,6 +21,7 @@ public class CommentResponseDto {
                 .commentId(comment.getId())
                 .commentator(comment.getCommentator().getUsername())
                 .commentatorId(comment.getCommentator().getUserId())
+                .profileImageId(comment.getCommentator().getProfileImageId())
                 .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())
                 .build();

--- a/src/main/java/efub/cpbr/crumble/community/comment/service/CommentService.java
+++ b/src/main/java/efub/cpbr/crumble/community/comment/service/CommentService.java
@@ -34,6 +34,7 @@ public class CommentService {
         Comment newComment = requestDto.toEntity(commentator, post);
 
         post.increaseCommentCount();
+        post.getAnswer().getUser().getUserStat().increaseCommentCount();
         commentRepository.save(newComment);
 
         // ⭐ 포인트 +2
@@ -55,6 +56,7 @@ public class CommentService {
         Post post = comment.getPost();
 
         post.decreaseCommentCount();
+        post.getAnswer().getUser().getUserStat().decreaseCommentCount();
         commentRepository.delete(comment);
     }
 

--- a/src/main/java/efub/cpbr/crumble/community/like/service/LikeService.java
+++ b/src/main/java/efub/cpbr/crumble/community/like/service/LikeService.java
@@ -42,6 +42,7 @@ public class LikeService {
         Like newLike = new Like(post, user);
 
         post.increaseLikeCount();
+        post.getAnswer().getUser().getUserStat().increaseLikeCount();
         likeRepository.save(newLike);
 
         // ⭐ 포인트 +2
@@ -62,6 +63,7 @@ public class LikeService {
 
         Post post = like.getPost();
         post.decreaseLikeCount();
+        post.getAnswer().getUser().getUserStat().decreaseLikeCount();
 
         likeRepository.delete(like);
     }

--- a/src/main/java/efub/cpbr/crumble/community/post/dto/Response/PostResponseDto.java
+++ b/src/main/java/efub/cpbr/crumble/community/post/dto/Response/PostResponseDto.java
@@ -11,6 +11,7 @@ import java.util.List;
 @Getter
 public class PostResponseDto {
     private Long id;
+    private Long userId;
     private String username;
     private int profileImageId;
     private String title;
@@ -27,6 +28,7 @@ public class PostResponseDto {
     public static PostResponseDto from(Post post, PostCommentDto comments) {
         return PostResponseDto.builder()
                 .id(post.getId())
+                .userId(post.getAnswer().getUser().getUserId())
                 .username(post.getAnswer().getUser().getUsername())
                 .profileImageId(post.getAnswer().getUser().getProfileImageId())
                 .title(post.getAnswer().getQuestion().getContent())

--- a/src/main/java/efub/cpbr/crumble/community/post/dto/Response/PostResponseDto.java
+++ b/src/main/java/efub/cpbr/crumble/community/post/dto/Response/PostResponseDto.java
@@ -12,6 +12,8 @@ import java.util.List;
 public class PostResponseDto {
     private Long id;
     private String username;
+    private int profileImageId;
+    private String title;
     private String content;
     private Long viewCount;
     private Long likeCount;
@@ -26,6 +28,8 @@ public class PostResponseDto {
         return PostResponseDto.builder()
                 .id(post.getId())
                 .username(post.getAnswer().getUser().getUsername())
+                .profileImageId(post.getAnswer().getUser().getProfileImageId())
+                .title(post.getAnswer().getQuestion().getContent())
                 .content(post.getContent())
                 .viewCount(post.getViewCount())
                 .likeCount(post.getLikeCount())

--- a/src/main/java/efub/cpbr/crumble/community/post/dto/Response/PostSummaryDto.java
+++ b/src/main/java/efub/cpbr/crumble/community/post/dto/Response/PostSummaryDto.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 @Getter
 public class PostSummaryDto {
     private Long id;
+    private Long userId;
     private String username;
     private int profileImageId;
     private String title;
@@ -24,6 +25,7 @@ public class PostSummaryDto {
     public static PostSummaryDto from(Post post) {
         return PostSummaryDto.builder()
                 .id(post.getId())
+                .userId(post.getAnswer().getUser().getUserId())
                 .username(post.getAnswer().getUser().getUsername())
                 .profileImageId(post.getAnswer().getUser().getProfileImageId())
                 .title(post.getAnswer().getQuestion().getContent())

--- a/src/main/java/efub/cpbr/crumble/community/post/dto/Response/PostSummaryDto.java
+++ b/src/main/java/efub/cpbr/crumble/community/post/dto/Response/PostSummaryDto.java
@@ -11,6 +11,8 @@ import java.time.LocalDateTime;
 public class PostSummaryDto {
     private Long id;
     private String username;
+    private int profileImageId;
+    private String title;
     private String content;
     private Long viewCount;
     private Long likeCount;
@@ -23,6 +25,8 @@ public class PostSummaryDto {
         return PostSummaryDto.builder()
                 .id(post.getId())
                 .username(post.getAnswer().getUser().getUsername())
+                .profileImageId(post.getAnswer().getUser().getProfileImageId())
+                .title(post.getAnswer().getQuestion().getContent())
                 .content(post.getContent())
                 .viewCount(post.getViewCount())
                 .likeCount(post.getLikeCount())

--- a/src/main/java/efub/cpbr/crumble/global/config/CorsConfig.java
+++ b/src/main/java/efub/cpbr/crumble/global/config/CorsConfig.java
@@ -1,6 +1,7 @@
 package efub.cpbr.crumble.global.config;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
@@ -11,6 +12,7 @@ import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
+@EnableConfigurationProperties(CorsProperties.class)
 public class CorsConfig {
     private final CorsProperties corsProperties;
 

--- a/src/main/java/efub/cpbr/crumble/global/config/WebSecurityConfig.java
+++ b/src/main/java/efub/cpbr/crumble/global/config/WebSecurityConfig.java
@@ -46,8 +46,7 @@ public class WebSecurityConfig {
                                 "/swagger-ui/**", // Swagger UI 접근 허용
                                 "/v3/api-docs/**",
                                 "/swagger-resources/**",
-                                "/webjars/**",
-                                "/shops/**" // 개발용, 로그인 개발 후 삭제
+                                "/webjars/**"
                         ).permitAll() // 위에 명시된 경로들은 인증 없이 접근 허용
                         .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요
                 )

--- a/src/main/java/efub/cpbr/crumble/user/controller/CommunityUser.java
+++ b/src/main/java/efub/cpbr/crumble/user/controller/CommunityUser.java
@@ -1,0 +1,36 @@
+package efub.cpbr.crumble.user.controller;
+
+import efub.cpbr.crumble.user.dto.response.CommunityUserResponseDto;
+import efub.cpbr.crumble.user.entity.User;
+import efub.cpbr.crumble.user.service.CommunityUserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/community/members")
+@RequiredArgsConstructor
+public class CommunityUser {
+
+    private final CommunityUserService communityUserService;
+
+    // 커뮤니티 유저 조회
+    @Operation(
+            summary = "커뮤니티 유저 조회",
+            description = "커뮤니티 유저를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/{memberId}")
+    public ResponseEntity<CommunityUserResponseDto> getMemberProfile(
+            @PathVariable Long memberId,
+            @AuthenticationPrincipal User user) {
+        CommunityUserResponseDto response = communityUserService.getMemberProfile(memberId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/user/controller/CommunityUser.java
+++ b/src/main/java/efub/cpbr/crumble/user/controller/CommunityUser.java
@@ -6,11 +6,13 @@ import efub.cpbr.crumble.user.service.CommunityUserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "CommunityUser", description = "커뮤니티 유저 관련 API")
 @RestController
 @RequestMapping("/community/members")
 @RequiredArgsConstructor

--- a/src/main/java/efub/cpbr/crumble/user/dto/response/CommunityUserResponseDto.java
+++ b/src/main/java/efub/cpbr/crumble/user/dto/response/CommunityUserResponseDto.java
@@ -1,0 +1,19 @@
+package efub.cpbr.crumble.user.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record CommunityUserResponseDto(UserProfileDto userProfile,
+                                       StatsDto stats,
+                                       List<DiaryPreviewDto> recentDiaries
+) {
+    public static CommunityUserResponseDto from(UserProfileDto userProfile, StatsDto stats, List<DiaryPreviewDto> diaries) {
+        return CommunityUserResponseDto.builder()
+                .userProfile(userProfile)
+                .stats(stats)
+                .recentDiaries(diaries)
+                .build();
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/user/dto/response/DiaryPreviewDto.java
+++ b/src/main/java/efub/cpbr/crumble/user/dto/response/DiaryPreviewDto.java
@@ -1,0 +1,28 @@
+package efub.cpbr.crumble.user.dto.response;
+
+import efub.cpbr.crumble.answer.entity.Answer;
+import efub.cpbr.crumble.question.entity.Question;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record DiaryPreviewDto(Long diaryId,
+                              Question question,
+                              String answer,
+                              Long likeCount,
+                              Long commentCount,
+                              LocalDateTime createdAt,
+                              boolean isPublic) {
+    public static DiaryPreviewDto from(Answer diary) {
+        return DiaryPreviewDto.builder()
+                .diaryId(diary.getId())
+                .question(diary.getQuestion())
+                .answer(diary.getContent())
+                .likeCount(diary.getPost().getLikeCount())
+                .commentCount(diary.getPost().getCommentCount())
+                .createdAt(diary.getCreatedAt())
+                .isPublic(diary.getIsPublic())
+                .build();
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/user/dto/response/StatsDto.java
+++ b/src/main/java/efub/cpbr/crumble/user/dto/response/StatsDto.java
@@ -1,0 +1,18 @@
+package efub.cpbr.crumble.user.dto.response;
+
+import efub.cpbr.crumble.user.entity.User;
+import efub.cpbr.crumble.user.entity.UserStat;
+import lombok.Builder;
+
+@Builder
+public record StatsDto(int likes,
+                       int comments,
+                       int diaries) {
+    public static StatsDto from(UserStat userStat) {
+        return StatsDto.builder()
+                .likes(userStat.getTotalLikesReceived())
+                .comments(userStat.getTotalCommentsReceived())
+                .diaries(userStat.getTotalAnswers())
+                .build();
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/user/dto/response/UserProfileDto.java
+++ b/src/main/java/efub/cpbr/crumble/user/dto/response/UserProfileDto.java
@@ -1,0 +1,17 @@
+package efub.cpbr.crumble.user.dto.response;
+
+import efub.cpbr.crumble.user.entity.User;
+import lombok.Builder;
+
+@Builder
+public record UserProfileDto(String username,
+                             String email,
+                             int profileImageId) {
+    public static UserProfileDto from(User user) {
+        return UserProfileDto.builder()
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .profileImageId(user.getProfileImageId())
+                .build();
+    }
+}

--- a/src/main/java/efub/cpbr/crumble/user/entity/User.java
+++ b/src/main/java/efub/cpbr/crumble/user/entity/User.java
@@ -52,13 +52,15 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private RoleType role;
 
+    private int profileImageId;
+
     public void addPoint(Long point) {
         this.point += point;
     }
 
     @Builder
     public User(Long userId, String username, String password, String email, String nickname,
-                int point, boolean isActive, LocalDateTime createdAt, LocalDateTime updatedAt, RoleType role) {
+                int point, boolean isActive, LocalDateTime createdAt, LocalDateTime updatedAt, RoleType role, int profileImageId) {
         this.userId = userId;
         this.username = username;
         this.password = password;
@@ -67,6 +69,7 @@ public class User extends BaseEntity {
         this.point = (point == 0) ? 0 : point; // 기본값 처리
         this.isActive = isActive;
         this.role = (role == null) ? RoleType.USER : role; // 기본 역할 처리
+        this.profileImageId = profileImageId;
     }
 
     /*public void deactivate() { // 사용자 탈퇴
@@ -88,5 +91,9 @@ public class User extends BaseEntity {
     // 보유 테마
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserPaper> userPapers = new ArrayList<>();
+
+    // 유저 활동
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private UserStat userStat;
 
 }

--- a/src/main/java/efub/cpbr/crumble/user/entity/UserStat.java
+++ b/src/main/java/efub/cpbr/crumble/user/entity/UserStat.java
@@ -1,0 +1,52 @@
+package efub.cpbr.crumble.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserStat {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userStatId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private int totalAnswers;
+
+    @Column(nullable = false)
+    private int currentStreak;
+
+    @Column(nullable = false)
+    private int longestStreak;
+
+    @Column(nullable = false)
+    private int totalLikesReceived;
+
+    @Column(nullable = false)
+    private int totalCommentsReceived;
+
+    public void increaseLikeCount() {
+        this.totalLikesReceived++;
+    }
+
+    public void increaseCommentCount() {
+        this.totalCommentsReceived++;
+    }
+
+    public void decreaseLikeCount() {
+        if (this.totalLikesReceived > 0) this.totalLikesReceived--;
+    }
+
+    public void decreaseCommentCount() {
+        if (this.totalCommentsReceived > 0) this.totalCommentsReceived--;
+    }
+
+}

--- a/src/main/java/efub/cpbr/crumble/user/entity/UserStat.java
+++ b/src/main/java/efub/cpbr/crumble/user/entity/UserStat.java
@@ -2,6 +2,7 @@ package efub.cpbr.crumble.user.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,6 +33,21 @@ public class UserStat {
 
     @Column(nullable = false)
     private int totalCommentsReceived;
+
+    @Builder
+    public UserStat(Long userStatId, User user, int totalAnswers, int currentStreak, int longestStreak, int totalLikesReceived, int totalCommentsReceived) {
+        this.userStatId = userStatId;
+        this.user = user;
+        this.totalAnswers = totalAnswers;
+        this.currentStreak = currentStreak;
+        this.longestStreak = longestStreak;
+        this.totalLikesReceived = totalLikesReceived;
+        this.totalCommentsReceived = totalCommentsReceived;
+    }
+
+    public void increaseTotalAnswers() {
+        this.totalAnswers ++;
+    }
 
     public void increaseLikeCount() {
         this.totalLikesReceived++;

--- a/src/main/java/efub/cpbr/crumble/user/repository/UserStatRepository.java
+++ b/src/main/java/efub/cpbr/crumble/user/repository/UserStatRepository.java
@@ -1,0 +1,7 @@
+package efub.cpbr.crumble.user.repository;
+
+import efub.cpbr.crumble.user.entity.UserStat;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserStatRepository extends JpaRepository<UserStat, Long> {
+}

--- a/src/main/java/efub/cpbr/crumble/user/service/CommunityUserService.java
+++ b/src/main/java/efub/cpbr/crumble/user/service/CommunityUserService.java
@@ -1,0 +1,41 @@
+package efub.cpbr.crumble.user.service;
+
+import efub.cpbr.crumble.answer.repository.AnswerRepository;
+import efub.cpbr.crumble.community.post.repository.PostRepository;
+import efub.cpbr.crumble.global.exception.CustomException;
+import efub.cpbr.crumble.global.exception.ErrorCode;
+import efub.cpbr.crumble.user.dto.response.CommunityUserResponseDto;
+import efub.cpbr.crumble.user.dto.response.DiaryPreviewDto;
+import efub.cpbr.crumble.user.dto.response.StatsDto;
+import efub.cpbr.crumble.user.dto.response.UserProfileDto;
+import efub.cpbr.crumble.user.entity.User;
+import efub.cpbr.crumble.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CommunityUserService {
+
+    private final UserRepository userRepository;
+    private final AnswerRepository answerRepository;
+
+    public CommunityUserResponseDto getMemberProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        UserProfileDto userProfile = UserProfileDto.from(user);
+
+        StatsDto stats = StatsDto.from(user.getUserStat());
+
+        List<DiaryPreviewDto> diaries = answerRepository
+                .findTop5ByUserAndIsPublicTrueOrderByCreatedAtDesc(user)
+                .stream()
+                .map(DiaryPreviewDto::from)
+                .toList();
+
+        return CommunityUserResponseDto.from(userProfile, stats, diaries);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,6 +32,7 @@ cors:
   allow-origins:
     - http://localhost:3000
     - http://localhost:5173
+    - https://qurumble.vercel.app
 
 openai:
   api-key: ${API_KEY}


### PR DESCRIPTION
## 🔧 작업 사항(Summary)<!--- 진행한 작업에 대해 설명해주세요. -->
- [x] UserStat 엔티티 작성
- [x] 회원가입 시 UserStat 생성 및 저장
- [x] 질문 답변, 댓글 생성/삭제, 좋아요 생성/삭제 시 UserStat 변경 내용 반영
- [x] 커뮤니티 유저 조회 api 기능 구현
- [x] 커뮤니티 게시글 응답 dto에 profileImageId, title 추가
- [x] cors allow origins 추가
- [x] post response dto에 userId 추가

## ✨ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가


## 📸 스크린샷 or Test 결과 (선택)

<img width="926" height="358" alt="image" src="https://github.com/user-attachments/assets/b36cc480-1598-4078-b915-017e7af9bd17" />

## 📌 Issue Number<!--- ex) #이슈이름, #이슈번호 -->
#11 
